### PR TITLE
PRD-1741 chore(deps): override vulnerable transitive deps (postcss, follow-redirects, yaml)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2880,15 +2880,16 @@
       "integrity": "sha512-8Bx950VD1bWTQJEH/AM6SpEk+SU55aVnp4Ujhuuxy3eMEBCRwBnTBnVXr9YAPvZL3/CNjCa8u4IWfNmEO53whA=="
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
+      "license": "MIT",
       "engines": {
         "node": ">=4.0"
       },
@@ -4388,9 +4389,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
       "funding": [
         {
           "type": "opencollective",
@@ -4405,10 +4406,11 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
@@ -5462,33 +5464,6 @@
         "url": "https://github.com/sponsors/antonk52"
       }
     },
-    "node_modules/tailwindcss/node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "dependencies": {
-        "nanoid": "^3.3.11",
-        "picocolors": "^1.1.1",
-        "source-map-js": "^1.2.1"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
     "node_modules/tailwindcss/node_modules/postcss-import": {
       "version": "15.1.0",
       "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
@@ -5556,22 +5531,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/tailwindcss/node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/text-table": {
@@ -6024,6 +5983,23 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
+    },
+    "node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
@@ -7043,7 +7019,7 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
       "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "requires": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
         "proxy-from-env": "^2.1.0"
       }
@@ -8007,9 +7983,9 @@
       "integrity": "sha512-8Bx950VD1bWTQJEH/AM6SpEk+SU55aVnp4Ujhuuxy3eMEBCRwBnTBnVXr9YAPvZL3/CNjCa8u4IWfNmEO53whA=="
     },
     "follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ=="
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw=="
     },
     "for-each": {
       "version": "0.3.5",
@@ -8791,7 +8767,7 @@
         "busboy": "1.6.0",
         "caniuse-lite": "^1.0.30001579",
         "graceful-fs": "^4.2.11",
-        "postcss": "8.4.31",
+        "postcss": "^8.5.10",
         "styled-jsx": "5.1.1"
       }
     },
@@ -9011,13 +8987,13 @@
       "dev": true
     },
     "postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
       "requires": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
       }
     },
     "postcss-focus-visible": {
@@ -9669,7 +9645,7 @@
         "normalize-path": "^3.0.0",
         "object-hash": "^3.0.0",
         "picocolors": "^1.1.1",
-        "postcss": "^8.4.47",
+        "postcss": "^8.5.10",
         "postcss-import": "^15.1.0",
         "postcss-js": "^4.0.1",
         "postcss-load-config": "^4.0.2 || ^5.0 || ^6.0",
@@ -9683,16 +9659,6 @@
           "version": "3.1.3",
           "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
           "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw=="
-        },
-        "postcss": {
-          "version": "8.5.6",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-          "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
-          "requires": {
-            "nanoid": "^3.3.11",
-            "picocolors": "^1.1.1",
-            "source-map-js": "^1.2.1"
-          }
         },
         "postcss-import": {
           "version": "15.1.0",
@@ -9720,13 +9686,6 @@
             "cssesc": "^3.0.0",
             "util-deprecate": "^1.0.2"
           }
-        },
-        "yaml": {
-          "version": "2.8.2",
-          "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-          "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
-          "optional": true,
-          "peer": true
         }
       }
     },
@@ -10045,6 +10004,13 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
+    },
+    "yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "optional": true,
+      "peer": true
     },
     "yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,11 @@
     "prettier": "^3.0.0",
     "prettier-plugin-tailwindcss": "^0.7.0"
   },
+  "overrides": {
+    "postcss": "^8.5.10",
+    "follow-redirects": "^1.16.0",
+    "yaml": "^2.8.3"
+  },
   "browser": {
     "fs": false,
     "path": false,


### PR DESCRIPTION
Closes the three remaining open Dependabot alerts that have no matching top-level dependency upgrade path — every vulnerable package is pulled in transitively, and the parent packages don't pin a fixed release in any version we'd reasonably accept (e.g. `next` still pins `postcss@8.4.31` even on `next@16`, `axios@1.15.2` still depends on `follow-redirects ^1.15.11`, `tailwindcss@3.x` is at its latest `3.4.19`).

Resolved with an `overrides` block in `package.json`:

| Package | Before | After | Required | Alert |
|---|---|---|---|---|
| `postcss` | `8.4.31` / `8.5.6` | `8.5.12` | `>= 8.5.10` | #83 — XSS via unescaped `</style>` |
| `follow-redirects` | `1.15.11` | `1.16.0` | `>= 1.16.0` | #80 — auth header leak on cross-domain redirect |
| `yaml` | `2.8.2` | `2.8.3` | `>= 2.8.3` | #72 — stack overflow via deeply nested collections |

### Why overrides instead of bumping a parent

- **`postcss`** — pinned by `next` (any version, including `15.5.15` in #48 and `16.x`), `autoprefixer`, `tailwindcss`. None bump past 8.5.10 in their current ranges.
- **`follow-redirects`** — pulled in by `axios`. Latest `axios` (1.15.2) still uses `follow-redirects ^1.15.11`.
- **`yaml`** — pulled in by `tailwindcss → postcss-load-config`. Bumping tailwind to v4 would be a major breaking change; we're already on the latest 3.x (3.4.19).

### Verification

- `npm install` cleanly resolves all three to the patched versions (verified via `npm ls postcss follow-redirects yaml --all`).
- `next build` succeeds; all 31 routes prerender unchanged.

This PR is independent of #48 (Next.js v15 security update). Merge order doesn't matter; whichever lands second will need a one-line lockfile rebase.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Forces newer versions of transitive build/runtime dependencies via `npm overrides`, which can cause subtle incompatibilities in CSS tooling or HTTP redirect behavior even though the change is limited to dependency resolution.
> 
> **Overview**
> Adds an `overrides` block in `package.json` to **force patched transitive versions** of `postcss`, `follow-redirects`, and `yaml`.
> 
> Updates `package-lock.json` to resolve these overrides, bumping `postcss` to `8.5.12`, `follow-redirects` to `1.16.0`, and `yaml` to `2.8.3`, and removing now-unneeded nested copies (e.g., under `tailwindcss`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d85f82dc50f4f1b61aab30cc6cb066237ee12e2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->