### PR TITLE
ci: add next build check on PRs and main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    name: next build
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build


### PR DESCRIPTION
## Summary

- Adds a GitHub Actions workflow that runs `next build` on every PR and push to `main`
- Catches build failures (e.g. invalid Next.js config, broken imports) before merge

## Context

During review of PR #48 (Next.js 14 → 15 upgrade), we found that `next.config.js` has `experimental.scrollRestoration: true` which Next.js 15 rejects with a hard error. There was no CI to catch this before merging. This workflow would have surfaced the issue automatically.

## Test plan

- [ ] Open a PR with a known build error and confirm the check blocks merge
- [ ] Confirm the check passes on a clean build of `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change that doesn’t affect runtime code; main risk is CI failures due to environment/version mismatches (Node 20/npm cache) or stricter build enforcement blocking merges.
> 
> **Overview**
> Adds a new GitHub Actions workflow (`.github/workflows/ci.yml`) that triggers on pushes and pull requests to `main` and runs a Node 20 job that installs dependencies (`npm ci`) and executes `npm run build` (i.e., `next build`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad9c19d871304ab8d07b256fd1088b592f20f99e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->