### PR TITLE
chore: remove debug console.log from _app layout selection

### DIFF
--- a/src/pages/_app.jsx
+++ b/src/pages/_app.jsx
@@ -65,7 +65,6 @@ export default function App({ Component, pageProps }) {
 
   // Determine the layout to use
   const layout = pageProps.markdoc?.frontmatter.layout || 'default'
-  console.log('Selected layout:', layout)
 
   const LayoutComponent = {
     default: DefaultLayout,


### PR DESCRIPTION
## Summary

- Removes `console.log('Selected layout:', layout)` from `_app.jsx`

This debug statement was printing 31 times during Netlify's static page generation and would also appear in browser consoles in production. Spotted during review of PR #48.

## Test plan

- [ ] Confirm Netlify build logs no longer show "Selected layout:" lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 2fe067c4738806a83f06cadab300b963d4c8d955. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->