### PR TITLE
fix(deps): restore postcss override to fix CVE-2026-41305

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5071,34 +5071,6 @@
         "react": "^18 || ^19"
       }
     },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
     "node_modules/node-exports-info": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.0.tgz",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,9 @@
     "prettier": "^3.0.0",
     "prettier-plugin-tailwindcss": "^0.7.0"
   },
+  "overrides": {
+    "postcss": "^8.5.10"
+  },
   "browser": {
     "fs": false,
     "path": false,


### PR DESCRIPTION
## Summary

- Restores `"postcss": "^8.5.10"` to the npm `overrides` block

## Root cause

`next@15.5.15` bundles its own `postcss@8.4.31` inside `node_modules/next/node_modules/postcss/`. That version is below the patched threshold (8.5.10) for [CVE-2026-41305](https://github.com/advisories/GHSA-XXX) — PostCSS XSS via unescaped `</style>` in CSS Stringify output.

The original `package.json` had `"overrides": { "postcss": "^8.5.10" }` to force npm to hoist the patched version. That override was inadvertently removed as part of the Next.js 15 upgrade PR (#48), reintroducing the vulnerability.

After this fix, `npm audit` reports **0 vulnerabilities**.

## Test plan

- [ ] `npm audit` returns no vulnerabilities
- [ ] `next build` passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency/lockfile-only change that pins `postcss` to a newer patched version; low functional risk aside from potential build/tooling incompatibilities if PostCSS behavior changes.
> 
> **Overview**
> Re-adds an npm `overrides` entry in `package.json` to force `postcss` to `^8.5.10`, preventing use of the older PostCSS version bundled under `next`.
> 
> Updates `package-lock.json` to reflect the override (removing the nested `next/node_modules/postcss` entry), aligning installs with the patched dependency version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d1a2b3b7ad01a3b645093e4489ea01c54a55343. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->