### PR TITLE
fix: bundle @docsearch/react to fix sitewide 500s on Netlify

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -4,6 +4,10 @@ const withMarkdoc = require('@markdoc/next.js')
 const nextConfig = {
   reactStrictMode: true,
   pageExtensions: ['js', 'jsx', 'md'],
+  // @docsearch/react v4 ships ESM syntax in .js files without "type": "module",
+  // so the externalized runtime require() crashes on Node 20 (Netlify Lambda).
+  // Bundling it via webpack avoids the runtime require entirely.
+  transpilePackages: ['@docsearch/react'],
 }
 
 module.exports = withMarkdoc()(nextConfig)


### PR DESCRIPTION
## Problem

docs.prodigyems.com has served **HTTP 500 on every HTML route** (including the 404 page) since 2026-07-03 19:28 UTC, when #36 (@docsearch/react v3 → v4) deployed.

Netlify function logs show every invocation failing with:

```
SyntaxError: Cannot use import statement outside a module
  at /var/task/node_modules/@docsearch/react/dist/esm/index.js:1
  at 7818 (.next/server/pages/_app.js:1:523)
```

## Root cause

@docsearch/react v4 ships ESM syntax in `.js` files without `"type": "module"`. The Next.js pages router externalizes node_modules in the server bundle, so `_app.js` `require()`s the package at runtime. On Netlify's `nodejs20.x` Lambda that parse fails (Node 20 has no module-syntax detection). Node 24 locally rescues the broken packaging via syntax detection, which is why builds and local dev never caught it.

## Fix

`transpilePackages: ['@docsearch/react']` makes webpack bundle the package into the server chunk, eliminating the runtime `require()`.

## Verification

- Bisected Netlify deploy permalinks: last good = react-player v3 deploy, first bad = docsearch v4 deploy
- Reproduced the exact SyntaxError locally: `node@20.18 -e 'require(".next/server/pages/_app.js")'`
- After this fix: zero externalized `require("@docsearch/react")` in the server bundle; `_app.js` loads clean under Node 20.18; `next start` under Node 20 serves 200 on `/` and `/docs/*`, 404 on unknown routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NhGWp3geXAjzZ1roRdUDNr

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single build-config change with no auth, data, or app logic touched; main risk is a webpack/bundle-size or build-time regression for DocSearch.
> 
> **Overview**
> Adds **`transpilePackages: ['@docsearch/react']`** to Next config so webpack bundles DocSearch into the server chunk instead of leaving a runtime `require()` on the ESM-only v4 package.
> 
> That change targets the post–#36 failure mode where Netlify **Node 20** Lambdas throw `Cannot use import statement outside a module` on every page render, which had turned the docs site into sitewide **500**s. Inline comments document why v4’s packaging breaks externalized server requires and why bundling is the workaround.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e51b13c19fa93d41748cfa0fbff92d130610bdf5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->