### PR TITLE
ci: smoke test the production server on the runtime node version (PRD-2006)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ jobs:
   build:
     name: next build
     runs-on: ubuntu-latest
+    # A wedged server (accepts TCP, never responds) would otherwise hang the
+    # smoke-test curls until the 6-hour runner default.
+    timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -40,7 +43,7 @@ jobs:
           SERVER_PID=$!
 
           for i in $(seq 1 30); do
-            if curl -sf -o /dev/null http://localhost:3000/; then
+            if curl -sf --max-time 10 -o /dev/null http://localhost:3000/; then
               break
             fi
             sleep 1
@@ -48,7 +51,7 @@ jobs:
 
           check() {
             local path=$1 expected=$2 code
-            code=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:3000$path")
+            code=$(curl -s --max-time 10 -o /dev/null -w "%{http_code}" "http://localhost:3000$path")
             echo "$code  $path (expected $expected)"
             [ "$code" = "$expected" ]
           }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: actions/setup-node@v6
+      # .nvmrc is the single source of truth for the Node version: Netlify uses
+      # it for the build, the Netlify functions runtime follows the build
+      # version, and CI must match so that runtime-only failures (e.g. the
+      # PRD-2004 ESM parse crash, which only reproduced on the Lambda Node
+      # version) surface here instead of in production.
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '24'
+          node-version-file: '.nvmrc'
           cache: npm
 
       - name: Install dependencies
@@ -24,3 +29,33 @@ jobs:
 
       - name: Build
         run: npm run build
+
+      # `next build` succeeding is not enough: all pages are SSG'd at build
+      # time, so a crash in the server handler only shows up when a request is
+      # actually served (PRD-2004 shipped a sitewide 500 with a green build).
+      # Boot the production server and assert real responses.
+      - name: Smoke test production server
+        run: |
+          npx next start -p 3000 &
+          SERVER_PID=$!
+
+          for i in $(seq 1 30); do
+            if curl -sf -o /dev/null http://localhost:3000/; then
+              break
+            fi
+            sleep 1
+          done
+
+          check() {
+            local path=$1 expected=$2 code
+            code=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:3000$path")
+            echo "$code  $path (expected $expected)"
+            [ "$code" = "$expected" ]
+          }
+
+          check / 200
+          check /docs/user-management 200
+          check /individual 200
+          check /nonexistent-smoke-path 404
+
+          kill "$SERVER_PID"


### PR DESCRIPTION
## Why

PRD-2004 shipped a sitewide 500 with a fully green build: `next build` succeeds because pages are SSG'd, and CI ran a different Node major than the Netlify Lambda runtime, so the runtime-only ESM parse crash was invisible everywhere except production.

## What

1. **`setup-node` now reads `.nvmrc`** — the same file Netlify uses for the build, which the functions runtime follows. CI, build, and runtime can no longer drift apart.
2. **Post-build smoke test** — boots `next start` against the production build and asserts real HTTP responses: 200 on `/`, `/docs/user-management`, `/individual`; 404 on an unknown path (during the outage even 404s returned 500).
3. **SHA-pinned actions** per supply-chain policy.

## Verification

- Smoke script passes locally against current `main` under `bash -e` (Actions semantics)
- **Negative test:** rebuilt the PRD-2004 broken commit (`9471526`) and ran the same smoke under Node 20 — every route returns 500, so this job would have failed PR #36 and blocked the outage

Closes PRD-2006 (stretch item — deploy-preview HTTP assertion — intentionally deferred; the runtime-pin makes local `next start` equivalent for this failure class, as the negative test demonstrates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NhGWp3geXAjzZ1roRdUDNr

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to the CI workflow; no application runtime or auth/data paths are modified.
> 
> **Overview**
> CI now aligns the Node runtime with **`.nvmrc`** (same source Netlify uses) instead of a hardcoded major, so runtime-only failures that `next build` misses can surface in the pipeline.
> 
> After **`npm run build`**, a new step starts **`next start`**, waits for the server, and asserts HTTP status codes on `/`, `/docs/user-management`, `/individual` (200) and an unknown path (404), with per-curl timeouts and a **10-minute job timeout** to avoid hung smoke tests.
> 
> **`actions/checkout`** and **`actions/setup-node`** are pinned to full commit SHAs for supply-chain policy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 824a945032275fc573587f220b578c201ccceec9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->