### PR TITLE
chore(renovate): open PRs weekday mornings only

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ]
+  "extends": ["config:recommended"],
+  "timezone": "America/New_York",
+  "schedule": ["after 8am and before 12pm every weekday"],
+  "prConcurrentLimit": 5
 }


### PR DESCRIPTION
PRD-2004 shipped in a Friday-evening Renovate batch and sat broken all weekend. This restricts Renovate PR activity to weekday mornings (America/New_York) so a bad merge surfaces while people are looking, and caps concurrent PRs at 5 to keep the queue reviewable.

Automerge is deliberately **not** enabled: `main` requires an approving review, which Renovate can't satisfy — merges stay human.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NhGWp3geXAjzZ1roRdUDNr

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tooling-only Renovate schedule and concurrency settings; no application runtime or deployment logic changes.
> 
> **Overview**
> **Renovate** is configured to open and update dependency PRs only **weekday mornings (8am–12pm, America/New_York)** instead of running around the clock, so a bad dependency bump is more likely to be noticed during working hours.
> 
> A **`prConcurrentLimit` of 5** is added to keep the open Renovate queue smaller and easier to review. The `extends` array is also collapsed to a single line; behavior of `config:recommended` is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e37154576c80babf2967e084a95d93d481fe176c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->