### PR TITLE
feat: migrate prism-react-renderer to v2 (supersedes #46)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "next-hubspot": "^2.0.1",
         "postcss-focus-visible": "^11.0.0",
         "postcss-import": "^16.0.0",
-        "prism-react-renderer": "^1.3.5",
+        "prism-react-renderer": "^2.4.1",
         "react": "19.2.7",
         "react-dom": "19.2.7",
         "react-hubspot-form": "^1.3.7",
@@ -3193,6 +3193,12 @@
       "dependencies": {
         "undici-types": "~8.3.0"
       }
+    },
+    "node_modules/@types/prismjs": {
+      "version": "1.26.6",
+      "resolved": "https://registry.npmjs.org/@types/prismjs/-/prismjs-1.26.6.tgz",
+      "integrity": "sha512-vqlvI7qlMvcCBbVe0AKAb4f97//Hy0EBTaiW8AalRnG/xAN5zOiWWyrNqNXeq8+KAuvRewjCVY1+IPxk4RdNYw==",
+      "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "19.2.17",
@@ -8337,12 +8343,16 @@
       }
     },
     "node_modules/prism-react-renderer": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/prism-react-renderer/-/prism-react-renderer-1.3.5.tgz",
-      "integrity": "sha512-IJ+MSwBWKG+SM3b2SUfdrhC+gu01QkV2KmRQgREThBfSQRoufqRfxfHUxpG1WcaFjP+kojcFyO9Qqtpgt3qLCg==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/prism-react-renderer/-/prism-react-renderer-2.4.1.tgz",
+      "integrity": "sha512-ey8Ls/+Di31eqzUxC46h8MksNuGx/n0AAC8uKpwFau4RPDYLuE3EXTp8N8G2vX2N7UC/+IXeNUnlWBGGcAG+Ig==",
       "license": "MIT",
+      "dependencies": {
+        "@types/prismjs": "^1.26.0",
+        "clsx": "^2.0.0"
+      },
       "peerDependencies": {
-        "react": ">=0.14.9"
+        "react": ">=16.0.0"
       }
     },
     "node_modules/progress": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "next-hubspot": "^2.0.1",
     "postcss-focus-visible": "^11.0.0",
     "postcss-import": "^16.0.0",
-    "prism-react-renderer": "^1.3.5",
+    "prism-react-renderer": "^2.4.1",
     "react": "19.2.7",
     "react-dom": "19.2.7",
     "react-hubspot-form": "^1.3.7",

--- a/src/components/Fence.jsx
+++ b/src/components/Fence.jsx
@@ -1,13 +1,17 @@
 import { Fragment } from 'react'
-import Highlight, { defaultProps } from 'prism-react-renderer'
+import { Highlight } from 'prism-react-renderer'
+
+// Tokens are styled by src/styles/prism.css via `.token.*` classes. The empty
+// theme is the documented v2 way to opt out of inline theme styles (v1's
+// `theme={undefined}` + defaultProps equivalent).
+const cssOnlyTheme = { plain: {}, styles: [] }
 
 export function Fence({ children, language }) {
   return (
     <Highlight
-      {...defaultProps}
       code={children.trimEnd()}
       language={language}
-      theme={undefined}
+      theme={cssOnlyTheme}
     >
       {({ className, style, tokens, getTokenProps }) => (
         <pre className={className} style={style}>

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -1,21 +1,10 @@
 import { Fragment } from 'react'
 import Image from 'next/image'
 import clsx from 'clsx'
-import Highlight, { defaultProps } from 'prism-react-renderer'
-
 import { Button } from '@/components/Button'
 import { HeroBackground } from '@/components/HeroBackground'
 import blurCyanImage from '@/images/blur-cyan.png'
 import blurIndigoImage from '@/images/blur-indigo.png'
-
-const codeLanguage = 'javascript'
-const code = `export default {
-  strategy: 'predictive',
-  engine: {
-    cpus: 12,
-    backups: ['./storage/cache.wtf'],
-  },
-}`
 
 const tabs = [
   { name: 'cache-advance.config.js', isActive: true },


### PR DESCRIPTION
Renovate's #46 bumps the dep without the required code migration (v2 removed the default export and `defaultProps`), and it's lockfile-conflicted beyond `update-branch`. This PR does the bump plus the migration:

- `Fence`: named `Highlight` import; empty theme (`{ plain: {}, styles: [] }`) — the [documented v2 pattern](https://github.com/FormidableLabs/prism-react-renderer#faq) for CSS-class styling, equivalent to v1's `theme={undefined}`; token styling continues to come from `src/styles/prism.css`
- `Hero`: removed dead v1 imports/consts left from a removed code panel

**Verification:** build green; all pages 200 under `next start`; note that no current content page renders a code fence (zero `.token` spans on prod today), so there is no visual surface to regress.

Closes #46.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NhGWp3geXAjzZ1roRdUDNr

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency bump with a small, documented API migration in Fence and dead-code removal in Hero; no auth, data, or security-sensitive paths touched.
> 
> **Overview**
> Upgrades **prism-react-renderer** from v1 to **v2.4.1** and updates the one live integration so syntax highlighting keeps using **CSS** (`src/styles/prism.css`) instead of inline theme styles.
> 
> **`Fence`** now imports **`Highlight`** as a named export and passes the v2 **empty theme** (`{ plain: {}, styles: [] }`) in place of v1’s `defaultProps` and `theme={undefined}`. **`Hero`** drops unused v1 prism imports and sample code constants left over from a removed code panel.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89780984b2b94f15b58e1b3fe79772c0a877768e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->