### PR TITLE
fix(deps): bump js-yaml to 4.3.0 for merge-key DoS advisory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7039,9 +7039,19 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -8442,15 +8452,6 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
         "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-      }
-    },
-    "node_modules/react-aria/node_modules/clsx": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
-      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/react-dom": {


### PR DESCRIPTION
Resolves [Dependabot alert #87](https://github.com/ProdigyEMS/prodigy-documentation-site/security/dependabot/87): js-yaml quadratic-complexity DoS in merge-key handling, vulnerable <= 4.1.1, fixed 4.2.0. In-range (`^4`) lockfile-only bump to 4.3.0; build verified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NhGWp3geXAjzZ1roRdUDNr

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency patch with no application code changes; typical low-risk security lockfile update.
> 
> **Overview**
> Updates **`package-lock.json`** so resolved **`js-yaml`** moves from **4.1.1** to **4.3.0**, addressing a **merge-key DoS** advisory (quadratic complexity in versions **≤ 4.1.1**; fixed from **4.2.0**). Existing transitive ranges (`^4`) already permit this version, so no **`package.json`** edits are required.
> 
> The lockfile refresh also drops a nested **`react-aria`** copy of **`clsx`** in favor of the hoisted dependency tree.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71af8d96c59a2d19e34605e1871e36042d1c435e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->