### PR TITLE
feat: build with turbopack via a markdoc loader shim

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,10 @@ docs.prodigyems.com has a Route53 health check + CloudWatch alarm (`HealthCheckD
 - `transpilePackages: ['@docsearch/react']` in `next.config.js` works around that packaging bug (ESM syntax in `.js` files without `"type": "module"`). Removing it requires proving the package fixed its packaging.
 - Majors that change build tooling (Tailwind, Next itself) need real migration work — do not merge on a red preview.
 
+## Turbopack + Markdoc
+
+Builds run on Turbopack (Next 16 default). `@markdoc/next.js` 0.5.0's own Turbopack support is broken (incomplete loader options, bare-specifier resolution silently producing an empty schema, absolute-path imports), so `next.config.js` wires a hand-written `turbopack.rules` entry through the project-local shim `markdoc-turbopack-loader.js`. **Do not add `--webpack` back**: the webpack config is deliberately stripped from the final Next config, so webpack builds no longer compile `.md` pages. Remove the shim + rules when `@markdoc/next.js` ≥ 0.6.0 ships the upstream fix (markdoc/next.js#70).
+
 ## Tailwind v4 gotchas
 
 - In v4, the typography plugin's `.prose` rules land in the **same cascade layer as utilities**, so an equal-specificity `.prose :where(p)` rule can override utilities like `m-0` on elements rendered inside the page-level Prose wrapper (in v3 utilities always won). Components that render inside docs content must mark non-prose elements with `not-prose` (see `Callout.jsx`, `QuickLinks.jsx`). Symptom: mysterious extra margins inside callouts/cards.

--- a/markdoc-turbopack-loader.js
+++ b/markdoc-turbopack-loader.js
@@ -1,0 +1,54 @@
+/**
+ * Project-local shim around @markdoc/next.js's unmodified webpack loader so
+ * markdoc .md pages compile under Turbopack.
+ *
+ * Why this exists: Turbopack's webpack-loader compatibility layer provides a
+ * `this.getResolve()` whose resolver rejects the bare specifiers ('config',
+ * 'tags', 'nodes', 'functions') that the markdoc loader resolves against the
+ * schema directory with `preferRelative: true`. The upstream loader swallows
+ * that rejection and silently falls back to an EMPTY schema, which breaks
+ * rendering at prerender time. It also emits absolute-path imports, which
+ * Turbopack rejects ("server relative imports are not implemented yet").
+ *
+ * REMOVE THIS SHIM when @markdoc/next.js >= 0.6.0 ships: the fix was merged
+ * upstream (markdoc/next.js#67) but reverted over a Windows CI snapshot
+ * failure; the retry is markdoc/next.js#70. Once released, the plugin's own
+ * loader emits relative imports and this file plus the hand-written
+ * `turbopack.rules` block in next.config.js collapse into plain plugin
+ * options.
+ */
+const path = require('path')
+
+// Resolve the upstream loader relative to the plugin entry point; the
+// package's exports map does not expose ./src/loader as a subpath.
+const markdocLoader = require(
+  path.join(path.dirname(require.resolve('@markdoc/next.js')), 'loader.js'),
+)
+
+/**
+ * Delegates to the upstream markdoc loader with a Node-based resolver that
+ * (a) treats bare schema names as ./name, matching the preferRelative
+ * semantics the loader expects, and (b) returns paths RELATIVE to the .md
+ * file being compiled, because Turbopack cannot import absolute filesystem
+ * paths.
+ *
+ * @param {string} source - Raw markdown source of the .md module.
+ * @returns {void} The result is delivered via the loader's async callback.
+ */
+module.exports = function markdocTurbopackShim(source) {
+  const ctx = Object.create(this)
+  const importerDir = path.dirname(this.resourcePath)
+
+  ctx.getResolve = () => (dir, request) => {
+    const bare = request.startsWith('.') ? request : `./${request}`
+    const abs = require.resolve(bare, { paths: [dir] })
+    let rel = path.relative(importerDir, abs)
+    if (!rel.startsWith('.')) {
+      rel = `./${rel}`
+    }
+
+    return Promise.resolve(rel)
+  }
+
+  return markdocLoader.call(ctx, source)
+}

--- a/next.config.js
+++ b/next.config.js
@@ -1,3 +1,4 @@
+const path = require('path')
 const withMarkdoc = require('@markdoc/next.js')
 const { withSentryConfig } = require('@sentry/nextjs')
 
@@ -6,9 +7,33 @@ const nextConfig = {
   reactStrictMode: true,
   pageExtensions: ['js', 'jsx', 'md'],
   // @docsearch/react v4 ships ESM syntax in .js files without "type": "module",
-  // so the externalized runtime require() crashes on Node 20 (Netlify Lambda).
-  // Bundling it via webpack avoids the runtime require entirely.
+  // so the externalized runtime require() crashes on old-Node lambdas and the
+  // package must be bundled rather than required at runtime.
   transpilePackages: ['@docsearch/react'],
+  // Hand-written Turbopack rule for markdoc .md pages. @markdoc/next.js
+  // 0.5.0's own createTurbopackConfig omits the `dir`/`pagesDir` options its
+  // loader requires (path.resolve(dir, schemaPath) crashes; without pagesDir
+  // no getStaticProps is emitted), so the full option set is supplied here,
+  // routed through the local shim loader (see that file for the why and the
+  // removal condition — upstream fix pending in markdoc/next.js#70).
+  turbopack: {
+    rules: {
+      '*.md': {
+        loaders: [
+          {
+            loader: require.resolve('./markdoc-turbopack-loader.js'),
+            options: {
+              dir: __dirname,
+              pagesDir: path.join(__dirname, 'src', 'pages'),
+              schemaPath: './markdoc',
+              mode: 'static',
+            },
+          },
+        ],
+        as: '*.js',
+      },
+    },
+  },
 }
 
 /**
@@ -27,4 +52,16 @@ const sentryBuildOptions = {
 
 // withSentryConfig must be the outermost wrapper so it processes the final
 // config produced by withMarkdoc.
-module.exports = withSentryConfig(withMarkdoc()(nextConfig), sentryBuildOptions)
+const finalConfig = withSentryConfig(withMarkdoc()(nextConfig), sentryBuildOptions)
+
+// withMarkdoc's createTurbopackConfig emits an incomplete '*.md' rule under
+// the same key as ours and would win the spread; restore the complete rule.
+finalConfig.turbopack = nextConfig.turbopack
+
+// The builds are Turbopack-only now: drop the webpack config that withMarkdoc
+// unconditionally attaches (Next 16 fails fast on webpack config otherwise).
+// Consequence: `next build --webpack` no longer compiles .md pages — the
+// Turbopack path via the shim is the only supported build.
+delete finalConfig.webpack
+
+module.exports = finalConfig

--- a/next.config.js
+++ b/next.config.js
@@ -55,8 +55,19 @@ const sentryBuildOptions = {
 const finalConfig = withSentryConfig(withMarkdoc()(nextConfig), sentryBuildOptions)
 
 // withMarkdoc's createTurbopackConfig emits an incomplete '*.md' rule under
-// the same key as ours and would win the spread; restore the complete rule.
-finalConfig.turbopack = nextConfig.turbopack
+// the same key as ours and would win the spread. Restore ONLY our rule via a
+// merge: replacing the whole turbopack object would clobber what the other
+// wrappers added — notably Sentry's `debugIds: true` (Turbopack's native
+// debug-id emission, without which server stack traces never symbolicate;
+// Sentry skips its own injection when it believes native IDs are on) and
+// Sentry's instrumentation rules.
+finalConfig.turbopack = {
+  ...finalConfig.turbopack,
+  rules: {
+    ...finalConfig.turbopack?.rules,
+    '*.md': nextConfig.turbopack.rules['*.md'],
+  },
+}
 
 // The builds are Turbopack-only now: drop the webpack config that withMarkdoc
 // unconditionally attaches (Next 16 fails fast on webpack config otherwise).

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev --webpack",
-    "build": "next build --webpack",
+    "dev": "next dev",
+    "build": "next build",
     "start": "next start",
     "lint": "eslint ."
   },

--- a/src/lib/sentry-server-fallback.js
+++ b/src/lib/sentry-server-fallback.js
@@ -1,0 +1,20 @@
+import * as Sentry from '@sentry/nextjs'
+
+// Idempotent server-side Sentry init, imported from _app so it runs when any
+// page's server bundle loads. Needed because Netlify's Next runtime does not
+// reliably load instrumentation.js (opennextjs-netlify#3503) — with Turbopack
+// builds the static-import workaround in src/instrumentation.js stops being
+// enough (verified: a deliberate preview throw produced no Sentry event).
+// Guards: never on the client, never double-init (getClient()), and uses
+// `typeof window` rather than NEXT_RUNTIME so it still fires if the Netlify
+// bundle does not set that env var.
+if (
+  typeof window === 'undefined' &&
+  !Sentry.getClient() &&
+  process.env.NEXT_PUBLIC_SENTRY_DSN
+) {
+  Sentry.init({
+    dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+    tracesSampleRate: 0,
+  })
+}

--- a/src/pages/_app.jsx
+++ b/src/pages/_app.jsx
@@ -1,6 +1,9 @@
 import Head from 'next/head'
 import { slugifyWithCounter } from '@sindresorhus/slugify'
 import '../styles/globals.css'
+// Server-side Sentry init fallback for Netlify runtimes that skip
+// instrumentation.js (see the module for details). Must load with every page.
+import '@/lib/sentry-server-fallback'
 
 import DefaultLayout from '@/components/DefaultLayout'
 import UserLayout from '@/components/UserLayout'

--- a/src/pages/api/sentry-test.js
+++ b/src/pages/api/sentry-test.js
@@ -1,3 +1,7 @@
+import * as Sentry from '@sentry/nextjs'
+
+import '@/lib/sentry-server-fallback'
+
 /**
  * Deliberate server-side crash endpoint for verifying Sentry capture on the
  * deployed Netlify Lambda. PRD-2004 taught us that server-side crashes on
@@ -6,12 +10,18 @@
  * event arrive in Sentry. Hit /api/sentry-test?marker=<id> after a deploy to
  * re-verify the pipeline end to end.
  *
+ * Explicitly wrapped because API routes are not covered by pages/_error, and
+ * the instrumentation onRequestError hook does not run on Netlify runtimes
+ * that skip instrumentation.js (opennextjs-netlify#3503).
+ *
  * @param {import('next').NextApiRequest} req - Incoming API request.
  * @param {import('next').NextApiResponse} res - API response (never used; the throw happens first).
  * @returns {void} Never returns; always throws.
  */
-export default function handler(req, res) {
+function handler(req, res) {
   throw new Error(
     `Sentry verification error (deliberate) marker=${req.query.marker ?? 'none'}`
   )
 }
+
+export default Sentry.wrapApiHandlerWithSentry(handler, '/api/sentry-test')


### PR DESCRIPTION
Retires the `--webpack` opt-out from #95's Next 16 migration. Based on the research + sandboxed build experiments: `@markdoc/next.js` 0.5.0's own Turbopack support is broken in three independent ways (missing `dir`/`pagesDir` loader options; bare schema-specifier resolution silently producing an **empty schema**; absolute-path import emission Turbopack rejects). The upstream fix ([markdoc/next.js#67](https://github.com/markdoc/next.js/pull/67)) was merged then reverted over a Windows CI snapshot failure; the retry ([#70](https://github.com/markdoc/next.js/pull/70)) is open.

## What this does
- `markdoc-turbopack-loader.js`: ~20-line shim delegating to the **unmodified** upstream loader with a Node-based resolver returning schema imports relative to each `.md` file (the same approach as the upstream fix). Documented removal condition: `@markdoc/next.js >= 0.6.0`.
- Hand-written `turbopack.rules` entry supplying the full loader option set the plugin's own turbopack path omits.
- `--webpack` dropped from build + dev; the webpack config is stripped from the final Next config (**webpack builds no longer compile .md pages** — one-way door, documented in AGENTS.md).

## Verification
- Turbopack build: 29/29 routes, identical route list/markers to the webpack build; `.md` pages SSG with `getStaticProps`
- Smoke 200/200/200/404; markdoc content + TOC render; docs page height matches baseline (9697px)
- Dev mode boots on Turbopack and serves `.md` pages
- Lint clean; deliberate server throw captured in Sentry locally
- **Pending on preview:** throw test + confirm the Sentry event still has source-mapped frames (validates `withSentryConfig`'s Turbopack source-map path now that the webpack hook is gone) — result below before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NhGWp3geXAjzZ1roRdUDNr

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes the only supported build path for all Markdoc pages and production observability on Netlify; a misconfigured Turbopack/Markdoc or Sentry fallback could cause runtime-only failures that still pass `next build`.
> 
> **Overview**
> **Switches the docs site to Turbopack-only builds** by removing `--webpack` from `dev`/`build` and deleting the final Next config’s `webpack` hook, so Markdoc `.md` pages compile only through a new hand-written `turbopack.rules['*.md']` entry (full `dir`/`pagesDir`/schema options the plugin omits).
> 
> Adds **`markdoc-turbopack-loader.js`**, a thin wrapper around `@markdoc/next.js`’s loader that fixes Turbopack’s broken `getResolve()` (empty schema) and forces **relative** schema import paths; **`next.config.js`** merges this rule back over the plugin’s incomplete rule while preserving Sentry’s Turbopack additions (`debugIds`, instrumentation rules). **AGENTS.md** documents the shim, the no-`--webpack` policy, and removal when `@markdoc/next.js` ≥ 0.6.0.
> 
> **Restores server-side Sentry on Netlify under Turbopack** with idempotent `src/lib/sentry-server-fallback.js` imported from `_app` and `/api/sentry-test`, plus `Sentry.wrapApiHandlerWithSentry` on the test route when `instrumentation.js` is skipped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1dc4e8928eafee179d13bd3bc44e7f8fcfde8977. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->