### PR TITLE
Add "Try This First" quick-fixes guide

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,7 @@ jobs:
           check / 200
           check /docs/user-management 200
           check /docs/network-troubleshooting 200
+          check /docs/try-this-first 200
           check /individual 200
           check /nonexistent-smoke-path 404
 

--- a/src/components/DefaultLayout.jsx
+++ b/src/components/DefaultLayout.jsx
@@ -57,6 +57,7 @@ const navigation = [
   {
     title: 'Technical Questions',
     links: [
+      { title: 'Try This First', href: '/docs/try-this-first' },
       { title: 'Do you Have an API?', href: '/docs/api' },
       { title: 'Is my Users Data Safe?', href: '/docs/data-safe' },
       { title: 'URL Allow List', href: '/docs/allow_list' },

--- a/src/pages/docs/try-this-first.md
+++ b/src/pages/docs/try-this-first.md
@@ -21,7 +21,7 @@ Click your profile and log out, then log back in. This refreshes your session, w
 
 ## Try an Incognito or Private Window
 
-Open a private window with **Ctrl+Shift+N** (Chrome, Windows), **Cmd+Shift+N** (Chrome, Mac), or **Ctrl+Shift+P** (Edge and Firefox), and log in to Prodigy there.
+Open a private window with **Ctrl+Shift+N** (Chrome or Edge on Windows), **Cmd+Shift+N** (Chrome or Edge on Mac), or **Ctrl+Shift+P** / **Cmd+Shift+P** (Firefox), and log in to Prodigy there.
 
 If everything works in the private window, the culprit is almost always a **browser extension** (ad blockers and privacy tools are frequent offenders) or **stale site data**. Try disabling extensions for the Prodigy site, or clear the site's data: in Chrome, click the icon to the left of the address bar, choose **Site settings**, and click **Delete data**.
 

--- a/src/pages/docs/try-this-first.md
+++ b/src/pages/docs/try-this-first.md
@@ -31,11 +31,12 @@ If you're not already using them, try **Google Chrome** or **Microsoft Edge**. I
 
 ## Try a Different Network
 
-If you're on a department or station network, try the same thing from a phone hotspot or your home connection. If it works away from the station, a firewall or content filter on that network is likely blocking something Prodigy needs — send your IT department our [URL Allow List](/docs/allow_list).
+If you're on a department or station network, try the same thing from a phone hotspot or your home connection. If it works away from the station, a firewall or content filter on that network is likely blocking something Prodigy needs — send your IT department our [URL Allow List](/docs/allow_list), and point them to [Network Requirements for IT](/docs/network-requirements) for how to allow Prodigy properly.
 
 ## Still Stuck?
 
 You've ruled out the easy stuff. Two ways to go from here:
 
+- If it's specifically a login, password, or account problem, see [Trouble Logging In?](/docs/login-help).
 - Follow the [Network Troubleshooting Guide](/docs/network-troubleshooting) to capture diagnostics our team can analyze.
 - Contact us at [Support@prodigyems.com](mailto:Support@prodigyems.com) or through the chat icon on the Prodigy page. Mention which of the checks above you already tried — it saves a round trip.

--- a/src/pages/docs/try-this-first.md
+++ b/src/pages/docs/try-this-first.md
@@ -1,0 +1,41 @@
+---
+title: Try This First
+description: Quick checks that solve most Prodigy issues in a couple of minutes, before you contact support or capture diagnostics.
+---
+
+Something not working? Most issues we hear about are solved by one of the quick checks on this page — each takes under a minute. Work through them in order, and if the problem survives all of them, you'll have narrowed down the cause for us.
+
+---
+
+## Check the Status Page
+
+Visit [status.prodigyems.com](https://status.prodigyems.com). If there's an active incident, the problem is on our end and already being worked on — no need to troubleshoot anything. The status page updates as we make progress.
+
+## Do a Hard Refresh
+
+Your browser may be holding on to an outdated copy of the page. Press **Ctrl+Shift+R** (Windows) or **Cmd+Shift+R** (Mac) to reload the page while skipping the cache.
+
+## Log Out and Back In
+
+Click your profile and log out, then log back in. This refreshes your session, which fixes problems like pages that load halfway or actions that silently fail after the browser has been open a long time.
+
+## Try an Incognito or Private Window
+
+Open a private window with **Ctrl+Shift+N** (Chrome, Windows), **Cmd+Shift+N** (Chrome, Mac), or **Ctrl+Shift+P** (Edge and Firefox), and log in to Prodigy there.
+
+If everything works in the private window, the culprit is almost always a **browser extension** (ad blockers and privacy tools are frequent offenders) or **stale site data**. Try disabling extensions for the Prodigy site, or clear the site's data: in Chrome, click the icon to the left of the address bar, choose **Site settings**, and click **Delete data**.
+
+## Try a Different Browser
+
+If you're not already using them, try **Google Chrome** or **Microsoft Edge**. If the problem only happens in one browser, note that — it's a useful clue for our team.
+
+## Try a Different Network
+
+If you're on a department or station network, try the same thing from a phone hotspot or your home connection. If it works away from the station, a firewall or content filter on that network is likely blocking something Prodigy needs — send your IT department our [URL Allow List](/docs/allow_list).
+
+## Still Stuck?
+
+You've ruled out the easy stuff. Two ways to go from here:
+
+- Follow the [Network Troubleshooting Guide](/docs/network-troubleshooting) to capture diagnostics our team can analyze.
+- Contact us at [Support@prodigyems.com](mailto:Support@prodigyems.com) or through the chat icon on the Prodigy page. Mention which of the checks above you already tried — it saves a round trip.


### PR DESCRIPTION
Adds `/docs/try-this-first` — a quick checklist customers can run before contacting support or capturing diagnostics: status page, hard refresh, re-login, incognito window (extension/site-data isolation), different browser, different network. Ends by routing to the Network Troubleshooting Guide or support with the checks already ruled out.

Nav: added at the top of Technical Questions.

Verified: `next build` passes with the page prerendering cleanly.

Note: this PR and #network-requirements both insert into the Technical Questions nav block a few lines apart — whichever merges second may need a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0127w9EY73bVSgY1aPP8RmBS

---
_Generated by [Claude Code](https://claude.ai/code/session_0127w9EY73bVSgY1aPP8RmBS)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and navigation only; no auth, data, or application logic changes.
> 
> **Overview**
> Adds a new **`/docs/try-this-first`** doc page with a short ordered checklist (status page, hard refresh, re-login, private window, alternate browser/network) so customers can rule out common issues before support or diagnostics.
> 
> **Technical Questions** nav in `DefaultLayout` now lists **Try This First** at the top of that section. CI smoke tests assert the new route returns **200**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f5d1a6e088fb5a454153710eb8d3532209ff877. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->