### PR TITLE
docs: add Google Workspace SSO setup guide

### DIFF
--- a/src/components/DefaultLayout.jsx
+++ b/src/components/DefaultLayout.jsx
@@ -27,7 +27,12 @@ const navigation = [
       { title: 'Certifications', href: '/docs/certifications' },
       { title: 'Certification Alerts', href: '/docs/alerts' },
       { title: 'Managing Groups', href: '/docs/groups' },
-      { title: 'Organization View', href: '/docs/organization' },
+      { title: 'Organization View', href: '/docs/organization' }
+    ],
+  },
+  {
+    title: 'Single Sign-On',
+    links: [
       { title: 'Google Workspace SSO', href: '/docs/google-workspace-sso' }
     ],
   },
@@ -59,7 +64,6 @@ const navigation = [
     title: 'Technical Questions',
     links: [
       { title: 'Do you Have an API?', href: '/docs/api' },
-      { title: 'Google Workspace SSO', href: '/docs/google-workspace-sso' },
       { title: 'Is my Users Data Safe?', href: '/docs/data-safe' },
       { title: 'URL Allow List', href: '/docs/allow_list' },
       { title: 'Network Troubleshooting', href: '/docs/network-troubleshooting' },

--- a/src/components/DefaultLayout.jsx
+++ b/src/components/DefaultLayout.jsx
@@ -27,7 +27,8 @@ const navigation = [
       { title: 'Certifications', href: '/docs/certifications' },
       { title: 'Certification Alerts', href: '/docs/alerts' },
       { title: 'Managing Groups', href: '/docs/groups' },
-      { title: 'Organization View', href: '/docs/organization' }
+      { title: 'Organization View', href: '/docs/organization' },
+      { title: 'Google Workspace SSO', href: '/docs/google-workspace-sso' }
     ],
   },
   {
@@ -58,6 +59,7 @@ const navigation = [
     title: 'Technical Questions',
     links: [
       { title: 'Do you Have an API?', href: '/docs/api' },
+      { title: 'Google Workspace SSO', href: '/docs/google-workspace-sso' },
       { title: 'Is my Users Data Safe?', href: '/docs/data-safe' },
       { title: 'URL Allow List', href: '/docs/allow_list' },
       { title: 'Network Troubleshooting', href: '/docs/network-troubleshooting' },

--- a/src/components/DefaultLayout.jsx
+++ b/src/components/DefaultLayout.jsx
@@ -33,7 +33,10 @@ const navigation = [
   {
     title: 'Single Sign-On',
     links: [
-      { title: 'Google Workspace SSO', href: '/docs/google-workspace-sso' }
+      { title: 'Google Workspace SAML', href: '/docs/google-workspace-saml-sso' },
+      { title: 'Okta SAML', href: '/docs/okta-saml-sso' },
+      { title: 'Microsoft Entra SAML', href: '/docs/microsoft-entra-saml-sso' },
+      { title: 'Other SAML 2.0 Providers', href: '/docs/saml-sso' }
     ],
   },
   {

--- a/src/pages/docs/api.md
+++ b/src/pages/docs/api.md
@@ -9,8 +9,8 @@ We often get requested to link other systems with Prodigy to make the user exper
 ## Single Sign On
 Many services choose to use our Single Sign On (SSO) option to access Prodigy. Many organizations use SSO solutions provided by third-party vendors, which integrate with their existing systems and applications.
 
-If your organization uses **Google Workspace**, you can connect it yourself, see our [Google Workspace SSO guide](/docs/google-workspace-sso) for step-by-step setup instructions.
+You can connect a SAML 2.0 identity provider yourself, see the step-by-step guides for [Google Workspace](/docs/google-workspace-saml-sso), [Okta](/docs/okta-saml-sso), [Microsoft Entra ID](/docs/microsoft-entra-saml-sso), or [other SAML 2.0 providers](/docs/saml-sso).
 
-For other identity providers, we can integrate with standard SSO systems. If you have an existing system you use for authentication, let us know and we can work with them to allow SSO.
+If you have an existing system you use for authentication that isn't covered above, let us know and we can work with them to allow SSO.
 ## Other Integrations
-We currently don't maintain any public documentation on using our API. If you have other systems that you are looking integrate with Prodigy reach out to [Support@prodigyems.com](mailto:Support@prodigyems.com) and we can discuss the options.
+We currently don't maintain any public documentation on using our API. If you have other systems that you are looking integrate with Prodigy reach out to [support@prodigyems.com](mailto:support@prodigyems.com) and we can discuss the options.

--- a/src/pages/docs/api.md
+++ b/src/pages/docs/api.md
@@ -7,6 +7,10 @@ We often get requested to link other systems with Prodigy to make the user exper
 
 ---
 ## Single Sign On
-Many services choose to use our Single Sign On (SSO) option to access Prodigy. Many organizations use SSO solutions provided by third-party vendors, which integrate with their existing systems and applications. We can integrate with standard SSO systems, if you have an existing system you use for authentication, let us know and we can work with them to allow SSO.
+Many services choose to use our Single Sign On (SSO) option to access Prodigy. Many organizations use SSO solutions provided by third-party vendors, which integrate with their existing systems and applications.
+
+If your organization uses **Google Workspace**, you can connect it yourself, see our [Google Workspace SSO guide](/docs/google-workspace-sso) for step-by-step setup instructions.
+
+For other identity providers, we can integrate with standard SSO systems. If you have an existing system you use for authentication, let us know and we can work with them to allow SSO.
 ## Other Integrations
 We currently don't maintain any public documentation on using our API. If you have other systems that you are looking integrate with Prodigy reach out to [Support@prodigyems.com](mailto:Support@prodigyems.com) and we can discuss the options.

--- a/src/pages/docs/google-workspace-saml-sso.md
+++ b/src/pages/docs/google-workspace-saml-sso.md
@@ -1,15 +1,19 @@
 ---
-title: Google Workspace SSO Setup
-description: Connect Google Workspace as your identity provider so your team can sign in to Prodigy with the Google account they already use.
+title: Google Workspace SAML SSO Setup
+description: Connect Google Workspace as a SAML identity provider so your team can sign in to Prodigy with the Google account they already use.
 ---
 
 {% callout type="note" title="New feature" %}
-Google Workspace SSO is new. If anything on this page doesn't match what you see, or you've got feedback, let us know at [Support@prodigyems.com](mailto:Support@prodigyems.com), we'd love to hear from you.
+Google Workspace SAML SSO is new. If anything on this page doesn't match what you see, or you've got feedback, let us know at [support@prodigyems.com](mailto:support@prodigyems.com), we'd love to hear from you.
 {% /callout %}
 
 ## What this does
 
-Connecting Google Workspace lets your team sign in to Prodigy with the Google account they already use for email and everything else, no separate Prodigy password to remember. The first time someone signs in this way, their Prodigy account is created automatically with the right name and department, so you don't need to create accounts by hand first.
+Connecting Google Workspace as a SAML identity provider lets your team sign in to Prodigy with the Google account they already use for email and everything else, no separate Prodigy password to remember. The first time someone signs in this way, their Prodigy account is created automatically with the right name and department, so you don't need to create accounts by hand first.
+
+{% callout type="note" title="SAML, specifically" %}
+This guide covers connecting Google Workspace via SAML. A lighter-weight Google sign-in option (OAuth/OIDC, similar to a "Sign in with Google" button) is coming soon as a separate guide, the two aren't the same setup.
+{% /callout %}
 
 ## Before you start
 
@@ -84,4 +88,4 @@ This is what's called an "IdP-initiated" sign-in, meaning your team starts from 
 
 ## Need help?
 
-If anything on your screen doesn't match what's described here, or a sign-in isn't working, reach out to [Support@prodigyems.com](mailto:Support@prodigyems.com) with a screenshot of where you're stuck and we'll help sort it out.
+If anything on your screen doesn't match what's described here, or a sign-in isn't working, reach out to [support@prodigyems.com](mailto:support@prodigyems.com) with a screenshot of where you're stuck and we'll help sort it out.

--- a/src/pages/docs/google-workspace-sso.md
+++ b/src/pages/docs/google-workspace-sso.md
@@ -1,0 +1,87 @@
+---
+title: Google Workspace SSO Setup
+description: Connect Google Workspace as your identity provider so your team can sign in to Prodigy with the Google account they already use.
+---
+
+{% callout type="note" title="New feature" %}
+Google Workspace SSO is new. If anything on this page doesn't match what you see, or you've got feedback, let us know at [Support@prodigyems.com](mailto:Support@prodigyems.com), we'd love to hear from you.
+{% /callout %}
+
+## What this does
+
+Connecting Google Workspace lets your team sign in to Prodigy with the Google account they already use for email and everything else, no separate Prodigy password to remember. The first time someone signs in this way, their Prodigy account is created automatically with the right name and department, so you don't need to create accounts by hand first.
+
+## Before you start
+
+You'll need:
+
+- A Google Workspace **admin** account with rights to add apps (Admin console access)
+- A Prodigy **organization admin** account
+- About 15 minutes
+
+## Step 1: Start the wizard in Prodigy
+
+In Prodigy, go to your organization's **Settings → Integrations → SAML Authentication** and choose **Google Workspace** when it asks which identity provider you're connecting. This screen shows you three values you'll need in a few minutes:
+
+- **ACS URL**
+- **SP Entity ID**
+- **SP Metadata URL**
+
+Keep this tab open, you'll come back to it.
+
+## Step 2: Create the custom SAML app in Google
+
+1. Sign in to [admin.google.com](https://admin.google.com) with your admin account.
+2. Go to **Apps → Web and mobile apps**.
+3. Click **Add app → Add custom SAML app**.
+4. Give the app a name, "Prodigy" works fine, and click **Continue**.
+5. Google now shows you *its own* sign-in details: an SSO URL, an Entity ID, and a certificate. You don't need to do anything with these by hand, just click **Download Metadata** to save them as a file, then click **Continue**. Prodigy's wizard can read that file directly instead of you copying each value one at a time.
+6. On the next screen, paste the **ACS URL** and **SP Entity ID** from Prodigy's wizard (Step 1) into the matching **ACS URL** and **Entity ID** fields. Click **Continue**.
+
+## Step 3: Map the attributes
+
+By default, Google Workspace sends nothing to a custom SAML app until you explicitly map it. On the **Attribute mapping** screen, click **Add mapping** for each of these:
+
+| Google Directory attribute | App attribute |
+| --- | --- |
+| Basic Information > Primary email | `mail` |
+| Basic Information > First name | `givenName` |
+| Basic Information > Last name | `sn` |
+
+All three are required. Prodigy uses them to create and correctly name an account the first time someone signs in.
+
+{% callout type="note" title="About the Name ID" %}
+By default, Google uses the person's primary email as their unique sign-in identifier ("Name ID"). That works well for most organizations. If you're planning to load your roster into Prodigy ahead of time so training is already assigned before anyone's first sign-in, ask your Prodigy contact about mapping Name ID to a stable identifier instead of email, so a later email change doesn't disconnect someone from their pre-loaded account. See Google's [custom SAML app documentation](https://knowledge.workspace.google.com/admin/apps/set-up-your-own-custom-saml-app) for how to map Name ID to a custom attribute.
+{% /callout %}
+
+Click **Finish**.
+
+## Step 4: Turn on the app for your team
+
+New apps aren't visible to anyone in your organization until you turn them on.
+
+1. On the app's overview page, click **User access**.
+2. Choose who should get access, usually **ON for everyone**, unless you'd rather roll it out to a smaller group first.
+3. Click **Save**.
+
+{% callout type="note" title="This can take a few hours" %}
+Google says access changes can take up to 24 hours to apply, though it's often much faster. If someone tries to sign in right away and it doesn't work, give it a little time before troubleshooting further.
+{% /callout %}
+
+## Step 5: Finish the wizard in Prodigy
+
+Back in the Prodigy tab from Step 1, either upload the metadata file you downloaded in Step 2, or paste in by hand:
+
+- The **Entity ID** Google showed you
+- The **SSO URL** Google showed you
+- The **Certificate** Google showed you
+
+Then choose which department new sign-ins should land in by default, save, and you're done.
+
+## How your team signs in
+
+This is what's called an "IdP-initiated" sign-in, meaning your team starts from Google, not from Prodigy's own login page. Once it's turned on, anyone with access can open the Google Apps grid (the dot icon next to their profile photo in Gmail or any other Google Workspace app) and click the Prodigy tile to be signed in automatically. There isn't a "Sign in with Google" button on Prodigy's login page yet, so it's worth pointing your team to that app grid, or bookmarking it, so they know where to start.
+
+## Need help?
+
+If anything on your screen doesn't match what's described here, or a sign-in isn't working, reach out to [Support@prodigyems.com](mailto:Support@prodigyems.com) with a screenshot of where you're stuck and we'll help sort it out.

--- a/src/pages/docs/microsoft-entra-saml-sso.md
+++ b/src/pages/docs/microsoft-entra-saml-sso.md
@@ -1,0 +1,81 @@
+---
+title: Microsoft Entra ID SAML SSO Setup
+description: Connect Microsoft Entra ID as a SAML identity provider so your team can sign in to Prodigy with their Microsoft account.
+---
+
+{% callout type="note" title="New feature" %}
+Microsoft Entra ID SAML SSO is new. If anything on this page doesn't match what you see, or you've got feedback, let us know at [support@prodigyems.com](mailto:support@prodigyems.com), we'd love to hear from you.
+{% /callout %}
+
+## What this does
+
+Connecting Microsoft Entra ID (formerly Azure AD) as a SAML identity provider lets your team sign in to Prodigy with the Microsoft account they already use for email and everything else, no separate Prodigy password to remember. The first time someone signs in this way, their Prodigy account is created automatically with the right name and department, so you don't need to create accounts by hand first.
+
+{% callout type="note" title="SAML, specifically" %}
+This guide covers connecting Microsoft Entra ID via SAML. A lighter-weight Microsoft sign-in option (OAuth/OIDC) is coming soon as a separate guide, the two aren't the same setup.
+{% /callout %}
+
+## Before you start
+
+You'll need:
+
+- A Microsoft Entra admin account (Cloud Application Administrator, Application Administrator, or owner of the app)
+- A Prodigy **organization admin** account
+- About 15 minutes
+
+## Step 1: Start the wizard in Prodigy
+
+In Prodigy, go to your organization's **Settings → Integrations → SAML Authentication** and choose **Microsoft Entra ID** when it asks which identity provider you're connecting. This screen shows you three values you'll need in a few minutes:
+
+- **ACS URL**
+- **SP Entity ID**
+- **SP Metadata URL**
+
+Keep this tab open, you'll come back to it.
+
+## Step 2: Create the enterprise application in Entra
+
+1. Sign in to the [Microsoft Entra admin center](https://entra.microsoft.com).
+2. Go to **Identity → Applications → Enterprise applications → New application**.
+3. Click **Create your own application**, give it a name ("Prodigy" works fine), and choose **Integrate any other application you don't find in the gallery (Non-gallery)**. Click **Create**.
+4. Open the new application and, in the **Manage** section, select **Single sign-on**.
+5. Choose **SAML**.
+6. In the **Basic SAML Configuration** section, click **Edit** and enter:
+   - **Identifier (Entity ID)**: the **SP Entity ID** from Prodigy's wizard (Step 1)
+   - **Reply URL (Assertion Consumer Service URL)**: the **ACS URL** from Prodigy's wizard
+7. Click **Save**.
+
+## Step 3: Check the attributes
+
+Entra's default claims already line up with what Prodigy needs, you generally don't need to change anything in the **Attributes & Claims** section. It's worth double-checking the following are present:
+
+| Claim | Read as |
+| --- | --- |
+| `.../ws/2005/05/identity/claims/emailaddress` | Email |
+| `.../ws/2005/05/identity/claims/givenname` | First name |
+| `.../ws/2005/05/identity/claims/surname` | Last name |
+
+{% callout type="note" title="About the Name ID" %}
+By default, Entra sends the person's User Principal Name (UPN) as the Name ID, which is fine, Prodigy matches on the email claim rather than the Name ID for Entra specifically. If you're planning to load your roster into Prodigy ahead of time so training is already assigned before anyone's first sign-in, mention this to your Prodigy contact so the matching can be set up to use a stable identifier.
+{% /callout %}
+
+## Step 4: Assign the app to your team
+
+New enterprise applications aren't visible to anyone until you assign them.
+
+1. In the app's **Manage** section, select **Users and groups**.
+2. Click **Add user/group** and choose who should get access.
+
+## Step 5: Finish the wizard in Prodigy
+
+Back in the Prodigy tab from Step 1, scroll to the **SAML Certificates** section and download the **Federation Metadata XML** file, then upload it into Prodigy's wizard. Or, if you'd rather enter things by hand, copy the **Login URL**, **Microsoft Entra Identifier**, and the certificate shown on the same page.
+
+Then choose which department new sign-ins should land in by default, save, and you're done.
+
+## How your team signs in
+
+This is what's called an "IdP-initiated" sign-in, meaning your team starts from Microsoft, not from Prodigy's own login page. Once the app is assigned, anyone with access can go to [myapps.microsoft.com](https://myapps.microsoft.com) (or the app launcher grid in Outlook or any other Microsoft 365 app) and click the Prodigy tile to be signed in automatically. There isn't a "Sign in with Microsoft" button on Prodigy's login page yet, so it's worth pointing your team to the app launcher so they know where to start.
+
+## Need help?
+
+If anything on your screen doesn't match what's described here, or a sign-in isn't working, reach out to [support@prodigyems.com](mailto:support@prodigyems.com) with a screenshot of where you're stuck and we'll help sort it out.

--- a/src/pages/docs/okta-saml-sso.md
+++ b/src/pages/docs/okta-saml-sso.md
@@ -42,6 +42,8 @@ Keep this tab open, you'll come back to it.
 5. On the **Configure SAML** tab, enter:
    - **Single sign-on URL**: the **ACS URL** from Prodigy's wizard (Step 1)
    - **Audience URI (SP Entity ID)**: the **SP Entity ID** from Prodigy's wizard
+   - **Name ID format**: **EmailAddress**
+   - **Application username**: **Email**
 
 ## Step 3: Map the attributes
 
@@ -56,7 +58,7 @@ Still on the **Configure SAML** tab, scroll to **Attribute Statements** and add 
 All three are required. Prodigy uses them to create and correctly name an account the first time someone signs in.
 
 {% callout type="note" title="About the Name ID" %}
-By default, Okta's **Name ID format** is left unspecified, which typically resolves to the person's email. That works well for most organizations. If you're planning to load your roster into Prodigy ahead of time so training is already assigned before anyone's first sign-in, consider setting **Name ID format** to **Persistent** instead of relying on email, so a later email change doesn't disconnect someone from their pre-loaded account.
+Use **EmailAddress** with the person's email as shown above. This matches the setup in Prodigy's in-app wizard and lets Okta launch Prodigy from the assigned app tile without any additional Name ID configuration.
 {% /callout %}
 
 Click **Next**, answer the "Are you a customer or partner" question (either is fine), and click **Finish**.

--- a/src/pages/docs/okta-saml-sso.md
+++ b/src/pages/docs/okta-saml-sso.md
@@ -1,0 +1,83 @@
+---
+title: Okta SAML SSO Setup
+description: Connect Okta as a SAML identity provider so your team can sign in to Prodigy with their Okta account.
+---
+
+{% callout type="note" title="New feature" %}
+Okta SAML SSO is new. If anything on this page doesn't match what you see, or you've got feedback, let us know at [support@prodigyems.com](mailto:support@prodigyems.com), we'd love to hear from you.
+{% /callout %}
+
+## What this does
+
+Connecting Okta as a SAML identity provider lets your team sign in to Prodigy with the Okta account they already use everywhere else, no separate Prodigy password to remember. The first time someone signs in this way, their Prodigy account is created automatically with the right name and department, so you don't need to create accounts by hand first.
+
+{% callout type="note" title="SAML, specifically" %}
+This guide covers connecting Okta via SAML. A lighter-weight Okta sign-in option (OAuth/OIDC) is coming soon as a separate guide, the two aren't the same setup.
+{% /callout %}
+
+## Before you start
+
+You'll need:
+
+- An Okta account with rights to create app integrations
+- A Prodigy **organization admin** account
+- About 15 minutes
+
+## Step 1: Start the wizard in Prodigy
+
+In Prodigy, go to your organization's **Settings → Integrations → SAML Authentication** and choose **Okta** when it asks which identity provider you're connecting. This screen shows you three values you'll need in a few minutes:
+
+- **ACS URL**
+- **SP Entity ID**
+- **SP Metadata URL**
+
+Keep this tab open, you'll come back to it.
+
+## Step 2: Create the app integration in Okta
+
+1. In the Okta Admin Console, go to **Applications → Applications**.
+2. Click **Create App Integration**.
+3. Choose **SAML 2.0** as the sign-in method and click **Next**.
+4. On the **General Settings** tab, give the integration a name, "Prodigy" works fine, and click **Next**.
+5. On the **Configure SAML** tab, enter:
+   - **Single sign-on URL**: the **ACS URL** from Prodigy's wizard (Step 1)
+   - **Audience URI (SP Entity ID)**: the **SP Entity ID** from Prodigy's wizard
+
+## Step 3: Map the attributes
+
+Still on the **Configure SAML** tab, scroll to **Attribute Statements** and add these three mappings:
+
+| Name (in Okta) | Value (Okta profile) |
+| --- | --- |
+| `mail` | `user.email` |
+| `givenName` | `user.firstName` |
+| `sn` | `user.lastName` |
+
+All three are required. Prodigy uses them to create and correctly name an account the first time someone signs in.
+
+{% callout type="note" title="About the Name ID" %}
+By default, Okta's **Name ID format** is left unspecified, which typically resolves to the person's email. That works well for most organizations. If you're planning to load your roster into Prodigy ahead of time so training is already assigned before anyone's first sign-in, consider setting **Name ID format** to **Persistent** instead of relying on email, so a later email change doesn't disconnect someone from their pre-loaded account.
+{% /callout %}
+
+Click **Next**, answer the "Are you a customer or partner" question (either is fine), and click **Finish**.
+
+## Step 4: Assign the app to your team
+
+New Okta app integrations aren't visible to anyone until you assign them.
+
+1. On the app's **Assignments** tab, click **Assign → Assign to People** or **Assign to Groups**.
+2. Choose who should get access and confirm.
+
+## Step 5: Finish the wizard in Prodigy
+
+Back in the Prodigy tab from Step 1, you'll need the app's IdP metadata. In Okta, open the app's **Sign On** tab and look for the SAML setup instructions or Identity Provider metadata link, either download the metadata and upload it into Prodigy's wizard, or copy the individual **Entity ID**, **SSO URL**, and **Certificate** values by hand.
+
+Then choose which department new sign-ins should land in by default, save, and you're done.
+
+## How your team signs in
+
+This is what's called an "IdP-initiated" sign-in, meaning your team starts from Okta, not from Prodigy's own login page. Once the app is assigned, anyone with access can open their Okta dashboard and click the Prodigy tile to be signed in automatically. There isn't a "Sign in with Okta" button on Prodigy's login page yet, so it's worth pointing your team to their Okta dashboard so they know where to start.
+
+## Need help?
+
+If anything on your screen doesn't match what's described here, or a sign-in isn't working, reach out to [support@prodigyems.com](mailto:support@prodigyems.com) with a screenshot of where you're stuck and we'll help sort it out.

--- a/src/pages/docs/saml-sso.md
+++ b/src/pages/docs/saml-sso.md
@@ -1,0 +1,83 @@
+---
+title: SAML SSO Setup (Other Identity Providers)
+description: Connect any SAML 2.0 identity provider, ADFS, PingOne, Auth0, WordPress plugins, and others, so your team can sign in to Prodigy with their existing account.
+---
+
+{% callout type="note" title="New feature" %}
+Self-service SAML SSO is new. If anything on this page doesn't match what you see, or you've got feedback, let us know at [support@prodigyems.com](mailto:support@prodigyems.com), we'd love to hear from you.
+{% /callout %}
+
+## What this does
+
+If your organization uses a SAML 2.0 identity provider other than Google Workspace, Okta, or Microsoft Entra ID, this covers everything else, ADFS, PingOne, Auth0, miniOrange for WordPress, or a custom setup. Connecting it lets your team sign in to Prodigy with the account they already use, no separate Prodigy password to remember. The first time someone signs in this way, their Prodigy account is created automatically with the right name and department, so you don't need to create accounts by hand first.
+
+{% callout type="note" title="Using Google, Okta, or Entra?" %}
+Those three have their own step-by-step guides with exact screens and field names: [Google Workspace](/docs/google-workspace-saml-sso), [Okta](/docs/okta-saml-sso), [Microsoft Entra ID](/docs/microsoft-entra-saml-sso).
+{% /callout %}
+
+## Before you start
+
+You'll need:
+
+- Admin access to your identity provider
+- A Prodigy **organization admin** account
+- About 15 minutes, this can take a little longer than the named-vendor guides since every provider's screens are laid out a little differently
+
+## Step 1: Start the wizard in Prodigy
+
+In Prodigy, go to your organization's **Settings → Integrations → SAML Authentication** and choose **Other SAML 2.0** when it asks which identity provider you're connecting. This screen shows you three values you'll need in a few minutes:
+
+- **ACS URL**
+- **SP Entity ID**
+- **SP Metadata URL**
+
+Keep this tab open, you'll come back to it.
+
+## Step 2: Create the application in your identity provider
+
+Every provider's setup screen is a little different, but they all ask for the same underlying information. Look for a section called something like "Add application," "New SAML app," or "Add relying party," and enter:
+
+- **ACS URL** (sometimes called Assertion Consumer Service URL, Reply URL, or Recipient URL): the **ACS URL** from Prodigy's wizard
+- **Entity ID** (sometimes called Audience URI, Identifier, or Relying Party Identifier): the **SP Entity ID** from Prodigy's wizard
+
+If your provider supports importing an SP metadata file or URL instead of entering these by hand, you can point it at the **SP Metadata URL** from Prodigy's wizard.
+
+{% callout type="note" title="Look for an \"unsolicited SSO\" or \"IdP-initiated\" switch" %}
+Prodigy's SAML connection currently only supports sign-ins that start from your identity provider, not from Prodigy's own login page. If your provider has a setting called "unsolicited SSO," "IdP-initiated SSO," or similar, make sure it's turned on.
+{% /callout %}
+
+## Step 3: Map the attributes
+
+Prodigy needs three attributes in the SAML assertion. Map them using these exact names:
+
+| Attribute | Contents | Required |
+| --- | --- | --- |
+| `mail` | Email address | Yes |
+| `givenName` | First name | Yes* |
+| `sn` | Last name | Yes* |
+
+\* If your provider can't split first and last name, map a single `cn` attribute with the person's full name instead, Prodigy will split it for you.
+
+Prodigy also accepts a few common aliases automatically, so if your provider only offers generic names, `email`, `firstName`/`given_name`, and `lastName`/`surname`/`family_name` all work too.
+
+{% callout type="note" title="About the Name ID" %}
+Using the person's email address as the Name ID (the unique sign-in identifier in the assertion) works well for most setups, and is what we'd recommend if your provider asks. If you're planning to load your roster into Prodigy ahead of time so training is already assigned before anyone's first sign-in, ask your Prodigy contact about using a more stable, non-email identifier instead, so a later email change doesn't disconnect someone from their pre-loaded account.
+{% /callout %}
+
+## Step 4: Turn on access for your team
+
+Every provider handles this differently, look for an option to assign the application to users or groups, or to publish/activate it. Until you do this, no one will be able to sign in.
+
+## Step 5: Finish the wizard in Prodigy
+
+Back in the Prodigy tab from Step 1, your identity provider will show you its own metadata, an Entity ID, an SSO URL, and a signing certificate, usually available as a downloadable XML file. Upload that file into Prodigy's wizard if it offers metadata import, or copy the three values in by hand.
+
+Then choose which department new sign-ins should land in by default, save, and you're done.
+
+## How your team signs in
+
+This is what's called an "IdP-initiated" sign-in, meaning your team starts from your identity provider, not from Prodigy's own login page. Once it's set up, anyone with access signs in from wherever your provider normally launches applications from, an app dashboard, a bookmarked link, or similar. There isn't a "Sign in with SSO" button on Prodigy's login page yet, so it's worth pointing your team to that starting point.
+
+## Need help?
+
+If you get stuck on a step that doesn't quite match your provider's screens, or a sign-in isn't working, reach out to [support@prodigyems.com](mailto:support@prodigyems.com) with a screenshot of where you're stuck and we'll help sort it out.


### PR DESCRIPTION
## What

Adds a step-by-step guide for connecting Google Workspace as a SAML identity provider: creating the custom SAML app in Google Admin console, mapping the required attributes (`mail`/`givenName`/`sn`), a note on Name ID for orgs planning to pre-load their roster, turning the app on, and finishing setup in Prodigy's wizard.

## Notes

- Framed as a new feature inviting feedback, not gated behind availability language.
- Not yet added to the sidebar nav (`DefaultLayout.jsx`) — can be wired in whenever it should become fully discoverable.
- No screenshots of the Google Admin console included; happy to add them if useful, but that needs either stock Google screenshots or a live walkthrough against a real tenant.
- Verified with `npm run lint` and `npm run build` locally, both clean.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and navigation only; no application or auth code changes.
> 
> **Overview**
> Adds **self-service SAML SSO documentation** for org admins: step-by-step guides for **Google Workspace**, **Okta**, **Microsoft Entra ID**, and a catch-all **Other SAML 2.0** page (IdP setup, attribute mapping, Prodigy wizard, IdP-initiated sign-in).
> 
> A new **Single Sign-On** section in the docs sidebar (`DefaultLayout.jsx`) links all four guides. The **Prodigy API** page’s SSO section now points to those guides instead of only “contact us,” and the support email is normalized to `support@prodigyems.com`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b1655c87b7cf89c52b66a7d06e0d9fb8b35f48c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->