### PR TITLE
docs(saml): document the first sign-in verification step

### DIFF
--- a/src/pages/docs/google-workspace-saml-sso.md
+++ b/src/pages/docs/google-workspace-saml-sso.md
@@ -80,11 +80,43 @@ Back in the Prodigy tab from Step 1, either upload the metadata file you downloa
 - The **SSO URL** Google showed you
 - The **Certificate** Google showed you
 
-Then choose which department new sign-ins should land in by default, save, and you're done.
+Then choose which department new sign-ins should land in by default and save. One more step confirms it's actually working.
+
+## Step 6: Confirm it's working
+
+Saving doesn't prove the connection works, so Prodigy checks for you. The moment you save, a panel appears reading **Waiting for the first sign-in… this page updates automatically.**
+
+Leave that tab open and do a real sign-in:
+
+1. Open the Google Apps grid, the dot icon next to your profile photo in Gmail or any other Google Workspace app.
+2. Click the Prodigy tile you created in Step 2.
+3. You should land in Prodigy, already signed in.
+
+Back on the settings tab, the panel turns green and names who signed in:
+
+**It works! someone@yourdomain.com signed in via SAML Authentication a few seconds ago.**
+
+That's your confirmation the connection is live. It's also the only real test available: an IdP-initiated setup has no meaningful "test connection" button, because a valid sign-in has to start at Google and come back to us.
+
+{% callout type="note" title="Only new sign-ins count" %}
+The check only counts sign-ins that happen after you save, so re-saving can't confirm itself against an older sign-in. If you change the configuration later, sign in again to re-confirm.
+{% /callout %}
+
+If nothing arrives after about 30 seconds, the wizard adds a hint:
+
+**No sign-in received yet. Double-check the IdP Entity ID matches exactly, and that your users are assigned to the Prodigy app in your identity provider.**
+
+Those two causes account for most first attempts that don't work. A mistyped Entity ID is the more common one, and it fails quietly: the assertion never gets matched to your organization at all, so nothing appears anywhere.
 
 ## How your team signs in
 
 This is what's called an "IdP-initiated" sign-in, meaning your team starts from Google, not from Prodigy's own login page. Once it's turned on, anyone with access can open the Google Apps grid (the dot icon next to their profile photo in Gmail or any other Google Workspace app) and click the Prodigy tile to be signed in automatically. There isn't a "Sign in with Google" button on Prodigy's login page yet, so it's worth pointing your team to that app grid, or bookmarking it, so they know where to start.
+
+## Keeping an eye on sign-ins
+
+The **Recent sign-in activity** card on the same settings page lists every SSO sign-in attempt, including the failures, with the reason each one was rejected. A person's first successful sign-in is marked **First sign-in — account created**, so you can watch accounts being provisioned as your team comes online.
+
+If someone tells you they can't sign in, start here. It will usually tell you what went wrong without needing to open a ticket.
 
 ## Need help?
 

--- a/src/pages/docs/microsoft-entra-saml-sso.md
+++ b/src/pages/docs/microsoft-entra-saml-sso.md
@@ -70,11 +70,43 @@ New enterprise applications aren't visible to anyone until you assign them.
 
 Back in the Prodigy tab from Step 1, scroll to the **SAML Certificates** section and download the **Federation Metadata XML** file, then upload it into Prodigy's wizard. Or, if you'd rather enter things by hand, copy the **Login URL**, **Microsoft Entra Identifier**, and the certificate shown on the same page.
 
-Then choose which department new sign-ins should land in by default, save, and you're done.
+Then choose which department new sign-ins should land in by default and save. One more step confirms it's actually working.
+
+## Step 6: Confirm it's working
+
+Saving doesn't prove the connection works, so Prodigy checks for you. The moment you save, a panel appears reading **Waiting for the first sign-in… this page updates automatically.**
+
+Leave that tab open and do a real sign-in:
+
+1. Open [myapps.microsoft.com](https://myapps.microsoft.com), or the app launcher grid in Outlook or any other Microsoft 365 app.
+2. Click the Prodigy tile you created in Step 2.
+3. You should land in Prodigy, already signed in.
+
+Back on the settings tab, the panel turns green and names who signed in:
+
+**It works! someone@yourdomain.com signed in via SAML Authentication a few seconds ago.**
+
+That's your confirmation the connection is live. It's also the only real test available: an IdP-initiated setup has no meaningful "test connection" button, because a valid sign-in has to start at Entra and come back to us.
+
+{% callout type="note" title="Only new sign-ins count" %}
+The check only counts sign-ins that happen after you save, so re-saving can't confirm itself against an older sign-in. If you change the configuration later, sign in again to re-confirm.
+{% /callout %}
+
+If nothing arrives after about 30 seconds, the wizard adds a hint:
+
+**No sign-in received yet. Double-check the IdP Entity ID matches exactly, and that your users are assigned to the Prodigy app in your identity provider.**
+
+Those two causes account for most first attempts that don't work. A mistyped Entity ID is the more common one, and it fails quietly: the assertion never gets matched to your organization at all, so nothing appears anywhere.
 
 ## How your team signs in
 
 This is what's called an "IdP-initiated" sign-in, meaning your team starts from Microsoft, not from Prodigy's own login page. Once the app is assigned, anyone with access can go to [myapps.microsoft.com](https://myapps.microsoft.com) (or the app launcher grid in Outlook or any other Microsoft 365 app) and click the Prodigy tile to be signed in automatically. There isn't a "Sign in with Microsoft" button on Prodigy's login page yet, so it's worth pointing your team to the app launcher so they know where to start.
+
+## Keeping an eye on sign-ins
+
+The **Recent sign-in activity** card on the same settings page lists every SSO sign-in attempt, including the failures, with the reason each one was rejected. A person's first successful sign-in is marked **First sign-in — account created**, so you can watch accounts being provisioned as your team comes online.
+
+If someone tells you they can't sign in, start here. It will usually tell you what went wrong without needing to open a ticket.
 
 ## Need help?
 

--- a/src/pages/docs/okta-saml-sso.md
+++ b/src/pages/docs/okta-saml-sso.md
@@ -74,11 +74,43 @@ New Okta app integrations aren't visible to anyone until you assign them.
 
 Back in the Prodigy tab from Step 1, you'll need the app's IdP metadata. In Okta, open the app's **Sign On** tab and look for the SAML setup instructions or Identity Provider metadata link, either download the metadata and upload it into Prodigy's wizard, or copy the individual **Entity ID**, **SSO URL**, and **Certificate** values by hand.
 
-Then choose which department new sign-ins should land in by default, save, and you're done.
+Then choose which department new sign-ins should land in by default and save. One more step confirms it's actually working.
+
+## Step 6: Confirm it's working
+
+Saving doesn't prove the connection works, so Prodigy checks for you. The moment you save, a panel appears reading **Waiting for the first sign-in… this page updates automatically.**
+
+Leave that tab open and do a real sign-in:
+
+1. Open your Okta End-User Dashboard.
+2. Click the Prodigy tile you created in Step 2.
+3. You should land in Prodigy, already signed in.
+
+Back on the settings tab, the panel turns green and names who signed in:
+
+**It works! someone@yourdomain.com signed in via SAML Authentication a few seconds ago.**
+
+That's your confirmation the connection is live. It's also the only real test available: an IdP-initiated setup has no meaningful "test connection" button, because a valid sign-in has to start at Okta and come back to us.
+
+{% callout type="note" title="Only new sign-ins count" %}
+The check only counts sign-ins that happen after you save, so re-saving can't confirm itself against an older sign-in. If you change the configuration later, sign in again to re-confirm.
+{% /callout %}
+
+If nothing arrives after about 30 seconds, the wizard adds a hint:
+
+**No sign-in received yet. Double-check the IdP Entity ID matches exactly, and that your users are assigned to the Prodigy app in your identity provider.**
+
+Those two causes account for most first attempts that don't work. A mistyped Entity ID is the more common one, and it fails quietly: the assertion never gets matched to your organization at all, so nothing appears anywhere.
 
 ## How your team signs in
 
 This is what's called an "IdP-initiated" sign-in, meaning your team starts from Okta, not from Prodigy's own login page. Once the app is assigned, anyone with access can open their Okta dashboard and click the Prodigy tile to be signed in automatically. There isn't a "Sign in with Okta" button on Prodigy's login page yet, so it's worth pointing your team to their Okta dashboard so they know where to start.
+
+## Keeping an eye on sign-ins
+
+The **Recent sign-in activity** card on the same settings page lists every SSO sign-in attempt, including the failures, with the reason each one was rejected. A person's first successful sign-in is marked **First sign-in — account created**, so you can watch accounts being provisioned as your team comes online.
+
+If someone tells you they can't sign in, start here. It will usually tell you what went wrong without needing to open a ticket.
 
 ## Need help?
 

--- a/src/pages/docs/saml-sso.md
+++ b/src/pages/docs/saml-sso.md
@@ -72,11 +72,43 @@ Every provider handles this differently, look for an option to assign the applic
 
 Back in the Prodigy tab from Step 1, your identity provider will show you its own metadata, an Entity ID, an SSO URL, and a signing certificate, usually available as a downloadable XML file. Upload that file into Prodigy's wizard if it offers metadata import, or copy the three values in by hand.
 
-Then choose which department new sign-ins should land in by default, save, and you're done.
+Then choose which department new sign-ins should land in by default and save. One more step confirms it's actually working.
+
+## Step 6: Confirm it's working
+
+Saving doesn't prove the connection works, so Prodigy checks for you. The moment you save, a panel appears reading **Waiting for the first sign-in… this page updates automatically.**
+
+Leave that tab open and do a real sign-in:
+
+1. Open wherever your identity provider launches applications from, usually an app dashboard or portal.
+2. Click the Prodigy application you created in Step 2.
+3. You should land in Prodigy, already signed in.
+
+Back on the settings tab, the panel turns green and names who signed in:
+
+**It works! someone@yourdomain.com signed in via SAML Authentication a few seconds ago.**
+
+That's your confirmation the connection is live. It's also the only real test available: an IdP-initiated setup has no meaningful "test connection" button, because a valid sign-in has to start at your identity provider and come back to us.
+
+{% callout type="note" title="Only new sign-ins count" %}
+The check only counts sign-ins that happen after you save, so re-saving can't confirm itself against an older sign-in. If you change the configuration later, sign in again to re-confirm.
+{% /callout %}
+
+If nothing arrives after about 30 seconds, the wizard adds a hint:
+
+**No sign-in received yet. Double-check the IdP Entity ID matches exactly, and that your users are assigned to the Prodigy app in your identity provider.**
+
+Those two causes account for most first attempts that don't work. A mistyped Entity ID is the more common one, and it fails quietly: the assertion never gets matched to your organization at all, so nothing appears anywhere.
 
 ## How your team signs in
 
 This is what's called an "IdP-initiated" sign-in, meaning your team starts from your identity provider, not from Prodigy's own login page. Once it's set up, anyone with access signs in from wherever your provider normally launches applications from, an app dashboard, a bookmarked link, or similar. There isn't a "Sign in with SSO" button on Prodigy's login page yet, so it's worth pointing your team to that starting point.
+
+## Keeping an eye on sign-ins
+
+The **Recent sign-in activity** card on the same settings page lists every SSO sign-in attempt, including the failures, with the reason each one was rejected. A person's first successful sign-in is marked **First sign-in — account created**, so you can watch accounts being provisioned as your team comes online.
+
+If someone tells you they can't sign in, start here. It will usually tell you what went wrong without needing to open a ticket.
 
 ## Need help?
 


### PR DESCRIPTION
## Why

All four SAML guides ended Step 5 with "save, and you're done." That is not where setup finishes, and it hides the most useful thing the wizard does.

After saving, `FirstSignInPanel` polls the provider's sign-in activity every 5s and flips from **"Waiting for the first sign-in… this page updates automatically"** to **"It works! {email} signed in via SAML Authentication {when}"** as soon as a real assertion lands. After 30s with nothing, it surfaces a hint pointing at the two usual causes. None of this was documented, so we were sending customers off to their app launcher to guess whether it worked.

This came up directly: a customer stalled mid-setup because the old flow required them to send us their IdP metadata so we could wire it up. Self-service shipped in v6.18.0, but the docs did not describe the verification half of it.

## What changed

Per guide (Entra, Google Workspace, Okta, generic SAML 2.0):

- Step 5 no longer claims you are done
- New **Step 6: Confirm it's working**, quoting the real product strings, with the app-launcher steps written for that specific IdP
- Callout noting only sign-ins *after* save count, matching the `since` lower bound in `FirstSignInPanel` (a re-save cannot confirm itself off a historical sign-in)
- New **Keeping an eye on sign-ins** section covering the Recent sign-in activity card, which logs failures with reasons

Copy is quoted verbatim from `frontend/src/locales/en/organization.json` (`samlSettings.wizard.review.*`, `samlSettings.activity.*`) so the docs and the UI cannot drift silently.

## Verification

- `npm run build` passes; all four pages prerender
- Rendered HTML checked for each page: Step 6 present, callout present, zero `{%` Markdoc leakage
- `npm run lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to customer-facing guides; no application or security behavior changes.
> 
> **Overview**
> The four SAML setup guides (Google Workspace, Microsoft Entra, Okta, and generic SAML) no longer end at **save** in Step 5. They now call out that **one more step** is required to confirm the connection.
> 
> Each guide adds **Step 6: Confirm it's working**, describing the post-save **first sign-in panel** (waiting state, success message, ~30s timeout hint), IdP-specific steps to launch a real sign-in from the app launcher, and a note that only sign-ins **after** save count toward verification. A new **Keeping an eye on sign-ins** section documents the **Recent sign-in activity** card for successes, failures with reasons, and first-time account creation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0840463b2df0b7facb0a79089a5bd7b3f32c85fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->