### PR TITLE
docs: make the org-admin prerequisite checkable in SSO setup guides (PRD-2213)

### DIFF
--- a/src/pages/docs/google-workspace-saml-sso.md
+++ b/src/pages/docs/google-workspace-saml-sso.md
@@ -23,6 +23,16 @@ You'll need:
 - A Prodigy **organization admin** account
 - About 15 minutes
 
+{% callout type="warning" title="Check your Prodigy role first" %}
+**Organization admin** is a specific role in Prodigy, not a general description of seniority. The next role down, **Training Officer**, can do most day-to-day administration but **cannot** complete this setup.
+
+**How to check:** look for **Settings** in the menu of your organization account. If it isn't there, you don't have the organization admin role.
+
+**How to get it:** email [support@prodigyems.com](mailto:support@prodigyems.com) and ask to be made an organization admin. A Training Officer can't grant this role, not even to themselves, so it does have to come from us.
+
+It's worth confirming before you begin. Setup runs several steps, and the permission is only checked when you save at the end.
+{% /callout %}
+
 ## Step 1: Start the wizard in Prodigy
 
 In Prodigy, go to your organization's **Settings → Integrations → SAML Authentication** and choose **Google Workspace** when it asks which identity provider you're connecting. This screen shows you three values you'll need in a few minutes:

--- a/src/pages/docs/google-workspace-saml-sso.md
+++ b/src/pages/docs/google-workspace-saml-sso.md
@@ -48,7 +48,7 @@ Keep this tab open, you'll come back to it.
 1. Sign in to [admin.google.com](https://admin.google.com) with your admin account.
 2. Go to **Apps → Web and mobile apps**.
 3. Click **Add app → Add custom SAML app**.
-4. Give the app a name, "Prodigy" works fine, and click **Continue**.
+4. Give the app a name, "Prodigy" works fine, upload the [Prodigy app icon](https://frontend.prodigyems.com/images/prodigyems/prodigy-app-icon-512.png), and click **Continue**.
 5. Google now shows you *its own* sign-in details: an SSO URL, an Entity ID, and a certificate. You don't need to do anything with these by hand, just click **Download Metadata** to save them as a file, then click **Continue**. Prodigy's wizard can read that file directly instead of you copying each value one at a time.
 6. On the next screen, paste the **ACS URL** and **SP Entity ID** from Prodigy's wizard (Step 1) into the matching **ACS URL** and **Entity ID** fields. Click **Continue**.
 

--- a/src/pages/docs/google-workspace-saml-sso.md
+++ b/src/pages/docs/google-workspace-saml-sso.md
@@ -28,7 +28,7 @@ You'll need:
 
 **How to check:** look for **Settings** in the menu of your organization account. If it isn't there, you don't have the organization admin role.
 
-**How to get it:** email [support@prodigyems.com](mailto:support@prodigyems.com) and ask to be made an organization admin. A Training Officer can't grant this role, not even to themselves, so it does have to come from us.
+**How to get it:** ask an existing organization admin at your organization to grant you the role. Every organization starts with one during onboarding. If you can't identify or reach yours, email [support@prodigyems.com](mailto:support@prodigyems.com) for help. A Training Officer can't grant this role, not even to themselves.
 
 It's worth confirming before you begin. Setup runs several steps, and the permission is only checked when you save at the end.
 {% /callout %}

--- a/src/pages/docs/microsoft-entra-saml-sso.md
+++ b/src/pages/docs/microsoft-entra-saml-sso.md
@@ -28,7 +28,7 @@ You'll need:
 
 **How to check:** look for **Settings** in the menu of your organization account. If it isn't there, you don't have the organization admin role.
 
-**How to get it:** email [support@prodigyems.com](mailto:support@prodigyems.com) and ask to be made an organization admin. A Training Officer can't grant this role, not even to themselves, so it does have to come from us.
+**How to get it:** ask an existing organization admin at your organization to grant you the role. Every organization starts with one during onboarding. If you can't identify or reach yours, email [support@prodigyems.com](mailto:support@prodigyems.com) for help. A Training Officer can't grant this role, not even to themselves.
 
 It's worth confirming before you begin. Setup runs several steps, and the permission is only checked when you save at the end.
 {% /callout %}

--- a/src/pages/docs/microsoft-entra-saml-sso.md
+++ b/src/pages/docs/microsoft-entra-saml-sso.md
@@ -48,6 +48,7 @@ Keep this tab open, you'll come back to it.
 1. Sign in to the [Microsoft Entra admin center](https://entra.microsoft.com).
 2. Go to **Identity → Applications → Enterprise applications → New application**.
 3. Click **Create your own application**, give it a name ("Prodigy" works fine), and choose **Integrate any other application you don't find in the gallery (Non-gallery)**. Click **Create**.
+   - Download the [Prodigy app icon](https://frontend.prodigyems.com/images/prodigyems/prodigy-app-icon-512.png) for the app's branding. Entra's **Properties** screen requires an exact 215 × 215 pixel PNG with a solid background and a file size under 100 KB, so resize the source icon to those requirements before uploading it.
 4. Open the new application and, in the **Manage** section, select **Single sign-on**.
 5. Choose **SAML**.
 6. In the **Basic SAML Configuration** section, click **Edit** and enter:

--- a/src/pages/docs/microsoft-entra-saml-sso.md
+++ b/src/pages/docs/microsoft-entra-saml-sso.md
@@ -23,6 +23,16 @@ You'll need:
 - A Prodigy **organization admin** account
 - About 15 minutes
 
+{% callout type="warning" title="Check your Prodigy role first" %}
+**Organization admin** is a specific role in Prodigy, not a general description of seniority. The next role down, **Training Officer**, can do most day-to-day administration but **cannot** complete this setup.
+
+**How to check:** look for **Settings** in the menu of your organization account. If it isn't there, you don't have the organization admin role.
+
+**How to get it:** email [support@prodigyems.com](mailto:support@prodigyems.com) and ask to be made an organization admin. A Training Officer can't grant this role, not even to themselves, so it does have to come from us.
+
+It's worth confirming before you begin. Setup runs several steps, and the permission is only checked when you save at the end.
+{% /callout %}
+
 ## Step 1: Start the wizard in Prodigy
 
 In Prodigy, go to your organization's **Settings → Integrations → SAML Authentication** and choose **Microsoft Entra ID** when it asks which identity provider you're connecting. This screen shows you three values you'll need in a few minutes:

--- a/src/pages/docs/okta-saml-sso.md
+++ b/src/pages/docs/okta-saml-sso.md
@@ -48,7 +48,7 @@ Keep this tab open, you'll come back to it.
 1. In the Okta Admin Console, go to **Applications → Applications**.
 2. Click **Create App Integration**.
 3. Choose **SAML 2.0** as the sign-in method and click **Next**.
-4. On the **General Settings** tab, give the integration a name, "Prodigy" works fine, and click **Next**.
+4. On the **General Settings** tab, give the integration a name, "Prodigy" works fine, upload the [Prodigy app icon](https://frontend.prodigyems.com/images/prodigyems/prodigy-app-icon-512.png), and click **Next**.
 5. On the **Configure SAML** tab, enter:
    - **Single sign-on URL**: the **ACS URL** from Prodigy's wizard (Step 1)
    - **Audience URI (SP Entity ID)**: the **SP Entity ID** from Prodigy's wizard

--- a/src/pages/docs/okta-saml-sso.md
+++ b/src/pages/docs/okta-saml-sso.md
@@ -23,6 +23,16 @@ You'll need:
 - A Prodigy **organization admin** account
 - About 15 minutes
 
+{% callout type="warning" title="Check your Prodigy role first" %}
+**Organization admin** is a specific role in Prodigy, not a general description of seniority. The next role down, **Training Officer**, can do most day-to-day administration but **cannot** complete this setup.
+
+**How to check:** look for **Settings** in the menu of your organization account. If it isn't there, you don't have the organization admin role.
+
+**How to get it:** email [support@prodigyems.com](mailto:support@prodigyems.com) and ask to be made an organization admin. A Training Officer can't grant this role, not even to themselves, so it does have to come from us.
+
+It's worth confirming before you begin. Setup runs several steps, and the permission is only checked when you save at the end.
+{% /callout %}
+
 ## Step 1: Start the wizard in Prodigy
 
 In Prodigy, go to your organization's **Settings → Integrations → SAML Authentication** and choose **Okta** when it asks which identity provider you're connecting. This screen shows you three values you'll need in a few minutes:

--- a/src/pages/docs/okta-saml-sso.md
+++ b/src/pages/docs/okta-saml-sso.md
@@ -28,7 +28,7 @@ You'll need:
 
 **How to check:** look for **Settings** in the menu of your organization account. If it isn't there, you don't have the organization admin role.
 
-**How to get it:** email [support@prodigyems.com](mailto:support@prodigyems.com) and ask to be made an organization admin. A Training Officer can't grant this role, not even to themselves, so it does have to come from us.
+**How to get it:** ask an existing organization admin at your organization to grant you the role. Every organization starts with one during onboarding. If you can't identify or reach yours, email [support@prodigyems.com](mailto:support@prodigyems.com) for help. A Training Officer can't grant this role, not even to themselves.
 
 It's worth confirming before you begin. Setup runs several steps, and the permission is only checked when you save at the end.
 {% /callout %}

--- a/src/pages/docs/saml-sso.md
+++ b/src/pages/docs/saml-sso.md
@@ -23,6 +23,16 @@ You'll need:
 - A Prodigy **organization admin** account
 - About 15 minutes, this can take a little longer than the named-vendor guides since every provider's screens are laid out a little differently
 
+{% callout type="warning" title="Check your Prodigy role first" %}
+**Organization admin** is a specific role in Prodigy, not a general description of seniority. The next role down, **Training Officer**, can do most day-to-day administration but **cannot** complete this setup.
+
+**How to check:** look for **Settings** in the menu of your organization account. If it isn't there, you don't have the organization admin role.
+
+**How to get it:** email [support@prodigyems.com](mailto:support@prodigyems.com) and ask to be made an organization admin. A Training Officer can't grant this role, not even to themselves, so it does have to come from us.
+
+It's worth confirming before you begin. Setup runs several steps, and the permission is only checked when you save at the end.
+{% /callout %}
+
 ## Step 1: Start the wizard in Prodigy
 
 In Prodigy, go to your organization's **Settings → Integrations → SAML Authentication** and choose **Other SAML 2.0** when it asks which identity provider you're connecting. This screen shows you three values you'll need in a few minutes:

--- a/src/pages/docs/saml-sso.md
+++ b/src/pages/docs/saml-sso.md
@@ -47,6 +47,7 @@ Keep this tab open, you'll come back to it.
 
 Every provider's setup screen is a little different, but they all ask for the same underlying information. Look for a section called something like "Add application," "New SAML app," or "Add relying party," and enter:
 
+- **Name**: Prodigy. If your provider supports a custom logo, use the [Prodigy app icon](https://frontend.prodigyems.com/images/prodigyems/prodigy-app-icon-512.png).
 - **ACS URL** (sometimes called Assertion Consumer Service URL, Reply URL, or Recipient URL): the **ACS URL** from Prodigy's wizard
 - **Entity ID** (sometimes called Audience URI, Identifier, or Relying Party Identifier): the **SP Entity ID** from Prodigy's wizard
 

--- a/src/pages/docs/saml-sso.md
+++ b/src/pages/docs/saml-sso.md
@@ -28,7 +28,7 @@ You'll need:
 
 **How to check:** look for **Settings** in the menu of your organization account. If it isn't there, you don't have the organization admin role.
 
-**How to get it:** email [support@prodigyems.com](mailto:support@prodigyems.com) and ask to be made an organization admin. A Training Officer can't grant this role, not even to themselves, so it does have to come from us.
+**How to get it:** ask an existing organization admin at your organization to grant you the role. Every organization starts with one during onboarding. If you can't identify or reach yours, email [support@prodigyems.com](mailto:support@prodigyems.com) for help. A Training Officer can't grant this role, not even to themselves.
 
 It's worth confirming before you begin. Setup runs several steps, and the permission is only checked when you save at the end.
 {% /callout %}

--- a/src/pages/docs/sftp-user-sync.md
+++ b/src/pages/docs/sftp-user-sync.md
@@ -26,6 +26,16 @@ You'll need:
 - An HR system (or any process) that can export a CSV and deliver it over SFTP on a schedule
 - An **SSH key pair** for authentication. Your HR system or SFTP client generates this; you'll paste the public key into Prodigy during setup. Both `ssh-rsa` and `ssh-ed25519` keys are supported, and no passwords are involved.
 
+{% callout type="warning" title="Check your Prodigy role first" %}
+**Organization admin** is a specific role in Prodigy, not a general description of seniority. The next role down, **Training Officer**, can do most day-to-day administration but **cannot** complete this setup.
+
+**How to check:** look for **Settings** in the menu of your organization account. If it isn't there, you don't have the organization admin role.
+
+**How to get it:** email [support@prodigyems.com](mailto:support@prodigyems.com) and ask to be made an organization admin. A Training Officer can't grant this role, not even to themselves, so it does have to come from us.
+
+It's worth confirming before you begin. Setup runs several steps, and the permission is only checked when you save at the end.
+{% /callout %}
+
 ## Step 1: Run the setup wizard
 
 In your organization account, go to **Settings → Integrations → FTP User Sync** and the setup wizard opens.

--- a/src/pages/docs/sftp-user-sync.md
+++ b/src/pages/docs/sftp-user-sync.md
@@ -31,7 +31,7 @@ You'll need:
 
 **How to check:** look for **Settings** in the menu of your organization account. If it isn't there, you don't have the organization admin role.
 
-**How to get it:** email [support@prodigyems.com](mailto:support@prodigyems.com) and ask to be made an organization admin. A Training Officer can't grant this role, not even to themselves, so it does have to come from us.
+**How to get it:** ask an existing organization admin at your organization to grant you the role. Every organization starts with one during onboarding. If you can't identify or reach yours, email [support@prodigyems.com](mailto:support@prodigyems.com) for help. A Training Officer can't grant this role, not even to themselves.
 
 It's worth confirming before you begin. Setup runs several steps, and the permission is only checked when you save at the end.
 {% /callout %}


### PR DESCRIPTION
Tracked as [PRD-2213](https://linear.app/proems/issue/PRD-2213/docs-make-the-org-admin-prerequisite-checkable-in-the-sso-setup-guides). Follows from [PRD-2208](https://linear.app/proems/issue/PRD-2208/welcome-to-prodigy-ems).

## Problem

Every SAML guide already lists this under **Before you start**:

> A Prodigy **organization admin** account

What it never says is how to tell whether you have one.

Chris Sayre at Vinton First Aid Crew is an IT professional and his department's retired chief. He read that bullet as obviously satisfied, followed the Google Workspace guide, filled in all five wizard steps, and got `The user is not authorized to perform this action` when he tried to save. He was a Training Officer, which sounds administrative and is not the role the page means.

## Change

A callout after the prerequisites list in all four SAML guides (`saml-sso`, `google-workspace-saml-sso`, `microsoft-entra-saml-sso`, `okta-saml-sso`) and in `sftp-user-sync`, which has the same requirement. It covers the three things the bullet leaves out:

- **Organization admin is a specific role**, not a description of seniority. Training Officer is the next role down and cannot complete the setup.
- **How to check**: Settings is absent from the organization menu without the role.
- **How to get it**: email support, because a Training Officer cannot grant it, not even to themselves. That last part is what leaves people stuck without knowing why.

It also warns that the permission is only checked at the save, so it's worth confirming before starting.

## Why this is worth five files

Roughly **100 of 1,174** production organizations have an org-level admin. Most readers of these pages do not currently have the role the pages assume.

## ⚠️ Merge after ProdigyEMS/prodigy#13886

The "look for Settings in the menu" check is only reliable once [prodigy#13886](https://github.com/ProdigyEMS/prodigy/pull/13886) ships. Today a Training Officer *can* see Settings — that's the bug being fixed there — so the check would give a false negative on the problem. Everything else in the callout is accurate now, but please let that one land first.

## Testing

- `npm run build` succeeds, all 39 static pages generate.
- `npm run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to setup guides; no application or security logic changes.
> 
> **Overview**
> Adds a **warning callout** after the prerequisites in all four SAML setup guides and the SFTP User Sync guide so readers can verify they have the **organization admin** role before starting multi-step wizards. The callout clarifies that **Training Officer** is not sufficient, how to check (**Settings** in the org menu), how to obtain the role (another org admin or support), and that authorization is only enforced when saving at the end.
> 
> The vendor-specific SAML steps also now point admins to the shared **Prodigy app icon** URL when naming or branding the IdP app (Google upload, Okta upload, Entra resize/upload, generic “other IdP” logo note).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b22c6b471b565f3f61dd8952e3479276eabff34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->