### PR TITLE
docs(saml): link app icon in setup guides (PRD-2217)

### DIFF
--- a/src/pages/docs/google-workspace-saml-sso.md
+++ b/src/pages/docs/google-workspace-saml-sso.md
@@ -48,7 +48,7 @@ Keep this tab open, you'll come back to it.
 1. Sign in to [admin.google.com](https://admin.google.com) with your admin account.
 2. Go to **Apps → Web and mobile apps**.
 3. Click **Add app → Add custom SAML app**.
-4. Give the app a name, "Prodigy" works fine, and click **Continue**.
+4. Give the app a name, "Prodigy" works fine, upload the [Prodigy app icon](https://frontend.prodigyems.com/images/prodigyems/prodigy-app-icon-512.png), and click **Continue**.
 5. Google now shows you *its own* sign-in details: an SSO URL, an Entity ID, and a certificate. You don't need to do anything with these by hand, just click **Download Metadata** to save them as a file, then click **Continue**. Prodigy's wizard can read that file directly instead of you copying each value one at a time.
 6. On the next screen, paste the **ACS URL** and **SP Entity ID** from Prodigy's wizard (Step 1) into the matching **ACS URL** and **Entity ID** fields. Click **Continue**.
 

--- a/src/pages/docs/microsoft-entra-saml-sso.md
+++ b/src/pages/docs/microsoft-entra-saml-sso.md
@@ -48,6 +48,7 @@ Keep this tab open, you'll come back to it.
 1. Sign in to the [Microsoft Entra admin center](https://entra.microsoft.com).
 2. Go to **Identity → Applications → Enterprise applications → New application**.
 3. Click **Create your own application**, give it a name ("Prodigy" works fine), and choose **Integrate any other application you don't find in the gallery (Non-gallery)**. Click **Create**.
+   - Download the [Prodigy app icon](https://frontend.prodigyems.com/images/prodigyems/prodigy-app-icon-512.png) for the app's branding. Entra's **Properties** screen requires an exact 215 × 215 pixel PNG with a solid background and a file size under 100 KB, so resize the source icon to those requirements before uploading it.
 4. Open the new application and, in the **Manage** section, select **Single sign-on**.
 5. Choose **SAML**.
 6. In the **Basic SAML Configuration** section, click **Edit** and enter:

--- a/src/pages/docs/okta-saml-sso.md
+++ b/src/pages/docs/okta-saml-sso.md
@@ -48,7 +48,7 @@ Keep this tab open, you'll come back to it.
 1. In the Okta Admin Console, go to **Applications → Applications**.
 2. Click **Create App Integration**.
 3. Choose **SAML 2.0** as the sign-in method and click **Next**.
-4. On the **General Settings** tab, give the integration a name, "Prodigy" works fine, and click **Next**.
+4. On the **General Settings** tab, give the integration a name, "Prodigy" works fine, upload the [Prodigy app icon](https://frontend.prodigyems.com/images/prodigyems/prodigy-app-icon-512.png), and click **Next**.
 5. On the **Configure SAML** tab, enter:
    - **Single sign-on URL**: the **ACS URL** from Prodigy's wizard (Step 1)
    - **Audience URI (SP Entity ID)**: the **SP Entity ID** from Prodigy's wizard

--- a/src/pages/docs/saml-sso.md
+++ b/src/pages/docs/saml-sso.md
@@ -47,6 +47,7 @@ Keep this tab open, you'll come back to it.
 
 Every provider's setup screen is a little different, but they all ask for the same underlying information. Look for a section called something like "Add application," "New SAML app," or "Add relying party," and enter:
 
+- **Name**: Prodigy. If your provider supports a custom logo, use the [Prodigy app icon](https://frontend.prodigyems.com/images/prodigyems/prodigy-app-icon-512.png).
 - **ACS URL** (sometimes called Assertion Consumer Service URL, Reply URL, or Recipient URL): the **ACS URL** from Prodigy's wizard
 - **Entity ID** (sometimes called Audience URI, Identifier, or Relying Party Identifier): the **SP Entity ID** from Prodigy's wizard
 


### PR DESCRIPTION
[Written by Claude]

## Summary

- link the shared Prodigy app icon from the Google Workspace, Microsoft Entra, Okta, and generic SAML setup guides
- place the link at each provider's application-branding step
- document Entra's current 215 × 215 solid-background PNG requirement so the transparent source asset is converted correctly

## Dependencies

- stacked on #125 to preserve its SSO prerequisite updates
- the linked asset is supplied by ProdigyEMS/prodigy#13897 and will resolve after that PR is deployed

## Test plan

- `npm run lint`
- `npm run build`
- verify the deploy-preview routes and icon link once Netlify publishes the preview

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only doc edits with no runtime or auth logic changes; only risk is a broken icon URL until the upstream asset deploy lands.
> 
> **Overview**
> Adds the shared **Prodigy app icon** URL to the IdP app-creation steps in the Google Workspace, Okta, generic SAML, and Microsoft Entra SAML guides so admins can brand the Prodigy tile during setup.
> 
> Google and Okta now tell readers to **upload** the icon at naming/general-settings. The generic guide adds a **Name / logo** bullet when the provider supports a custom logo. Entra adds a sub-step with **215 × 215 PNG**, solid background, and **under 100 KB** so the 512px source asset is prepared correctly for Properties branding.
> 
> All links point at `frontend.prodigyems.com/images/prodigyems/prodigy-app-icon-512.png` (asset availability depends on the related frontend deploy).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ec015012966c074a8d7d450a4c18c5900d2662b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->