### PR TITLE
fix(deps): patch transitive denial-of-service flaws

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7297,9 +7297,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",
@@ -7978,9 +7978,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
[Written by Claude]

## Summary

- update transitive js-yaml from 4.3.0 to 4.3.1 to resolve GHSA-5p4m-2wfm-xmqj
- update transitive nanoid from 3.3.16 to 3.3.18 to resolve CVE-2026-67213 across every shipped entry point
- keep the remediation lockfile-only because both parent dependency ranges already accept the patched versions

## Security context

Vanta and Dependabot reported the js-yaml quadratic CPU denial of service in the docs repository. A clean install also exposed the contemporaneous nanoid zero-size infinite-loop advisory. The upstream js-yaml patch is a focused backport that replaces linear duplicate-key scans for !!omap; nanoid 3.3.18 completes the zero/negative-size guard across its synchronous, async, browser, and React Native entry points.

This branch was authored by automation through the repository owner account. It must not merge until a different human teammate approves the final substantive diff.

## Validation

- npm ci
- npm audit --audit-level=high (0 vulnerabilities)
- npm run lint
- npm run build

## Runtime verification

Verified against https://deploy-preview-132--prodigydocumentation.netlify.app after Netlify completed the deploy:

- [x] / returns HTTP 200
- [x] /docs/alerts returns HTTP 200
- [x] /__codex-missing-preview-check__ returns HTTP 404
